### PR TITLE
test: Chain-agnostic test suite

### DIFF
--- a/.github/workflows/hurl-integration-tests.yml
+++ b/.github/workflows/hurl-integration-tests.yml
@@ -1,4 +1,4 @@
-name: ci
+name: hurl-integration-tests
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/rust-integration-tests.yml
+++ b/.github/workflows/rust-integration-tests.yml
@@ -1,0 +1,33 @@
+name: rust-integration-tests
+on:
+  schedule:
+    - cron: "0 8,20 * * *"
+  push:
+  workflow_dispatch:
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: build beerus
+        run: cargo build -p beerus-cli --release
+
+      - name: start beerus RPC on MAINNET
+        env:
+          BEERUS_VERSION: "ci"
+          NETWORK: "mainnet"
+          ETH_EXECUTION_RPC: ${{ secrets.ETH_EXECUTION_RPC_MAINNET }}
+          STARKNET_RPC: ${{ secrets.STARKNET_RPC_0_6_0_MAINNET }}
+        run: ./target/release/beerus & while ! timeout 1 bash -c "echo > /dev/tcp/localhost/3030" 2> /dev/null; do sleep 2; done
+
+      - name: run integration test on MAINNET
+        run: cargo test --package beerus-rpc --features integration-tests
+
+      - name: stop RPC
+        run: kill $(lsof -t -i:3030)
+ 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,8 +598,10 @@ name = "beerus-rpc"
 version = "0.4.0"
 dependencies = [
  "beerus-core",
+ "cached 0.49.3",
  "eyre",
  "jsonrpsee 0.20.3",
+ "lazy_static",
  "pretty_assertions",
  "reqwest",
  "serde",
@@ -736,7 +738,7 @@ dependencies = [
  "ark-ff",
  "ark-secp256k1",
  "ark-secp256r1",
- "cached",
+ "cached 0.44.0",
  "cairo-felt",
  "cairo-lang-casm",
  "cairo-lang-runner",
@@ -877,7 +879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b195e4fbc4b6862bbd065b991a34750399c119797efff72492f28a5864de8700"
 dependencies = [
  "async-trait",
- "cached_proc_macro",
+ "cached_proc_macro 0.17.0",
  "cached_proc_macro_types",
  "futures",
  "hashbrown 0.13.2",
@@ -888,12 +890,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cached"
+version = "0.49.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8e463fceca5674287f32d252fb1d94083758b8709c160efae66d263e5f4eba"
+dependencies = [
+ "ahash 0.8.7",
+ "cached_proc_macro 0.20.0",
+ "cached_proc_macro_types",
+ "hashbrown 0.14.3",
+ "instant",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
 name = "cached_proc_macro"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48814962d2fd604c50d2b9433c2a41a0ab567779ee2c02f7fba6eca1221f082"
 dependencies = [
  "cached_proc_macro_types",
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9f16c0d84de31a2ab7fdf5f7783c14631f7075cf464eb3bb43119f61c9cb2a"
+dependencies = [
  "darling 0.14.4",
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,11 +600,14 @@ dependencies = [
  "beerus-core",
  "eyre",
  "jsonrpsee 0.20.3",
+ "pretty_assertions",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_with",
  "starknet",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 
@@ -4760,6 +4763,16 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi 0.5.1",
+]
 
 [[package]]
 name = "prettyplease"

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -23,7 +23,7 @@ pub const DEFAULT_POLL_SECS: u64 = 5;
 pub const DEFAULT_FEE_TOKEN_ADDR: &str =
     "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7";
 const DEFAULT_IP_V4_ADDR: &str = "127.0.0.1";
-const DEFAULT_PORT: u16 = 3030;
+pub const DEFAULT_PORT: u16 = 3030;
 
 // mainnet constants
 pub const MAINNET_CC_ADDRESS: &str = "c662c410C0ECf747543f5bA90660f6ABeBD9C8c4";

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -4,11 +4,15 @@ edition = "2021"
 name = "beerus-rpc"
 version = "0.4.0"
 
+[features]
+integration-tests = ["pretty_assertions"]
+
 [dependencies]
 beerus-core = { path = "../core" }
 starknet.workspace = true
 eyre.workspace = true
 jsonrpsee = { version = "0.20.3", features = ["macros", "server", "server-core"] }
+pretty_assertions = { version = "1.4.0", optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_with.workspace = true
 thiserror.workspace = true
@@ -16,3 +20,5 @@ tracing.workspace = true
 
 [dev-dependencies]
 serde_json = "1.0"
+reqwest = "0.11.13"
+tokio.workspace = true

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -5,10 +5,11 @@ name = "beerus-rpc"
 version = "0.4.0"
 
 [features]
-integration-tests = ["pretty_assertions"]
+integration-tests = ["pretty_assertions", "cached"]
 
 [dependencies]
 beerus-core = { path = "../core" }
+cached = { version = "0.49.3", optional = true }
 starknet.workspace = true
 eyre.workspace = true
 jsonrpsee = { version = "0.20.3", features = ["macros", "server", "server-core"] }
@@ -19,6 +20,7 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+lazy_static = "1.4.0"
 serde_json = "1.0"
 reqwest = "0.11.13"
 tokio.workspace = true

--- a/crates/rpc/tests/rpc.rs
+++ b/crates/rpc/tests/rpc.rs
@@ -2,16 +2,26 @@
 #![cfg(feature = "integration-tests")]
 
 use beerus_core::config::DEFAULT_PORT;
+use cached::Cached;
+use std::{ops::Deref, sync::Mutex};
+
+use cached::SizedCache;
 use reqwest::Url;
 use starknet::{
     core::types::{
-        BlockId, BlockTag, BlockWithTxHashes, BlockWithTxs, DeclareTransaction,
+        BlockId, BlockWithTxHashes, BlockWithTxs, DeclareTransaction,
         DeployAccountTransaction, FieldElement, InvokeTransaction,
         MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
         MaybePendingTransactionReceipt, Transaction, TransactionReceipt,
     },
-    providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider},
+    providers::{
+        jsonrpc::HttpTransport, JsonRpcClient, Provider, ProviderError,
+    },
 };
+
+lazy_static::lazy_static! {
+    static ref BLOCK_CACHE: Mutex<SizedCache<u64, MaybePendingBlockWithTxs>> = Mutex::new(SizedCache::with_size(1000));
+}
 
 fn rpc_client() -> JsonRpcClient<HttpTransport> {
     let rpc_url: Url = format!("http://localhost:{}", DEFAULT_PORT)
@@ -20,8 +30,38 @@ fn rpc_client() -> JsonRpcClient<HttpTransport> {
     JsonRpcClient::new(HttpTransport::new(rpc_url))
 }
 
+struct TestClient {
+    inner: JsonRpcClient<HttpTransport>,
+}
+
+impl TestClient {
+    async fn get_cached_block_with_txs(
+        &mut self,
+        number: u64,
+    ) -> Result<MaybePendingBlockWithTxs, ProviderError> {
+        let mut cache = BLOCK_CACHE.lock().expect("Poisoned lock");
+        match cache.cache_get(&number) {
+            Some(block) => Ok(block.clone()),
+            None => {
+                let block =
+                    self.get_block_with_txs(BlockId::Number(number)).await?;
+                cache.cache_set(number, block.clone());
+                Ok(block)
+            }
+        }
+    }
+}
+
+impl Deref for TestClient {
+    type Target = JsonRpcClient<HttpTransport>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
 struct TestContext<T> {
-    client: JsonRpcClient<HttpTransport>,
+    client: TestClient,
     block: BlockWithTxs,
     block_id: BlockId,
     extracted_value: T,
@@ -54,10 +94,15 @@ async fn n_txs_context(min_tx_number: usize) -> TestContext<()> {
 async fn context<F: Fn(&BlockWithTxs) -> Option<T>, T>(
     extractor: F,
 ) -> TestContext<T> {
-    let client = rpc_client();
+    let mut client = TestClient { inner: rpc_client() };
+
+    let latest = client
+        .block_number()
+        .await
+        .expect("Failed to retrieve the latest block number");
 
     let block = match client
-        .get_block_with_txs(BlockId::Tag(BlockTag::Latest))
+        .get_cached_block_with_txs(latest)
         .await
         .expect("Failed to retrieve the latest block")
     {
@@ -91,7 +136,7 @@ async fn context<F: Fn(&BlockWithTxs) -> Option<T>, T>(
         }
 
         let block = match client
-            .get_block_with_txs(BlockId::Number(block_number))
+            .get_cached_block_with_txs(block_number)
             .await
             .expect("Block retrieval failed")
         {
@@ -409,20 +454,21 @@ async fn test_get_transaction_status() {
 /* TODO
    Add more test scenarios to cover the following methods:
 
-   starknet_block_hash_and_number
    starknet_call
    starknet_estimateFee
    starknet_estimateFeeSingle
-   starknet_getBalance
    starknet_getEvents
-   starknet_getProof
-   starknet_getStateRoot
    starknet_getStateUpdate
-   starknet_getStorateAt
+   starknet_getStorageAt
    starknet_getTransactionReceipt
-   starknet_getTransactionStatus
    starknet_syncing
    pathfinder_getProof
+
+   Extended endpoints (unsupported by starknet-rs' `JsonRpcClient`):
+
+   starknet_getStateRoot
+   starknet_getProof
+   starknet_getBalance
 */
 
 fn truncate_felt_to_u128(felt: &FieldElement) -> u128 {

--- a/crates/rpc/tests/rpc.rs
+++ b/crates/rpc/tests/rpc.rs
@@ -1,0 +1,430 @@
+// These tests need Beerus to run in the background, hence why they're hidden behind the following feature.
+#![cfg(feature = "integration-tests")]
+
+use beerus_core::config::DEFAULT_PORT;
+use reqwest::Url;
+use starknet::{
+    core::types::{
+        BlockId, BlockTag, BlockWithTxHashes, BlockWithTxs, DeclareTransaction,
+        DeployAccountTransaction, FieldElement, InvokeTransaction,
+        MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
+        MaybePendingTransactionReceipt, Transaction, TransactionReceipt,
+    },
+    providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider},
+};
+
+fn rpc_client() -> JsonRpcClient<HttpTransport> {
+    let rpc_url: Url = format!("http://localhost:{}", DEFAULT_PORT)
+        .parse()
+        .expect("Invalid RPC URL");
+    JsonRpcClient::new(HttpTransport::new(rpc_url))
+}
+
+struct TestContext<T> {
+    client: JsonRpcClient<HttpTransport>,
+    block: BlockWithTxs,
+    block_id: BlockId,
+    extracted_value: T,
+}
+
+/// Creates a `TestContext` with the latest block.
+async fn latest_block_context() -> TestContext<()> {
+    context(|_block| Some(())).await
+}
+
+/// Creates a `TestContext` with the latest block with at least N transactions.
+async fn n_txs_context(min_tx_number: usize) -> TestContext<()> {
+    context(|block| {
+        if block.transactions.len() >= min_tx_number {
+            Some(())
+        } else {
+            None
+        }
+    })
+    .await
+}
+
+/// Instantiate a client and look for a block matching the `extractor`, going from latest
+///  to older.
+///
+/// # Parameters
+///
+/// * `extractor`: a closure returning `Some(T)` in the case of a match. The value returned
+///  by the extractor will end up in the `TestContext`'s `extracted_value` field.
+async fn context<F: Fn(&BlockWithTxs) -> Option<T>, T>(
+    extractor: F,
+) -> TestContext<T> {
+    let client = rpc_client();
+
+    let block = match client
+        .get_block_with_txs(BlockId::Tag(BlockTag::Latest))
+        .await
+        .expect("Failed to retrieve the latest block")
+    {
+        MaybePendingBlockWithTxs::Block(block) => block,
+        MaybePendingBlockWithTxs::PendingBlock(_) => {
+            panic!("The latest block shouldn't be a pending block")
+        }
+    };
+
+    if let Some(extracted_value) = extractor(&block) {
+        return TestContext {
+            client,
+            block_id: BlockId::Number(block.block_number),
+            block,
+            extracted_value,
+        };
+    }
+
+    // The latest block doesn't match the criterion.
+    // Go to the lower blocks one by one until a match is found.
+
+    let mut limit = 1_000;
+    let mut block_number = block.block_number;
+
+    while limit > 0 {
+        limit -= 1;
+        block_number -= 1;
+
+        if block_number == 0 {
+            panic!("Reached the genesis block, still no suitable block found");
+        }
+
+        let block = match client
+            .get_block_with_txs(BlockId::Number(block_number))
+            .await
+            .expect("Block retrieval failed")
+        {
+            MaybePendingBlockWithTxs::Block(block) => block,
+            MaybePendingBlockWithTxs::PendingBlock(_) => {
+                continue;
+            }
+        };
+
+        if let Some(extracted_value) = extractor(&block) {
+            return TestContext {
+                client,
+                block_id: BlockId::Number(block.block_number),
+                block,
+                extracted_value,
+            };
+        }
+    }
+
+    panic!("No suitable block found")
+}
+
+// starknet_blockNumber is already tested in the creation of the test context.
+
+#[tokio::test]
+async fn test_chain_id() {
+    let client = rpc_client();
+
+    client.chain_id().await.expect("Failed to retrieve the chain ID");
+}
+
+#[tokio::test]
+async fn test_get_block_transaction_count() {
+    let TestContext { client, block, block_id, extracted_value: () } =
+        latest_block_context().await;
+
+    let tx_count = client
+        .get_block_transaction_count(block_id)
+        .await
+        .expect("Failed to retrieve the transaction count");
+    assert_eq!(tx_count, block.transactions.len() as u64);
+}
+
+// starknet_getBlockWithTxs is already tested in the creation of the test context.
+
+#[tokio::test]
+async fn test_get_block_with_tx_hashes() {
+    let txs = 10;
+    let TestContext { client, block, block_id, extracted_value: () } =
+        n_txs_context(txs).await;
+
+    let BlockWithTxHashes {
+        status,
+        block_hash,
+        parent_hash,
+        block_number,
+        new_root,
+        timestamp,
+        sequencer_address,
+        transactions,
+        l1_gas_price,
+        starknet_version,
+    } = match client.get_block_with_tx_hashes(block_id).await.expect("Failed to retrieve the block with transaction hashes") {
+        MaybePendingBlockWithTxHashes::Block(with_tx_hashes) => with_tx_hashes,
+        MaybePendingBlockWithTxHashes::PendingBlock(_) => panic!("This block was already verified as not pending, it shouldn't be a pending block now"),
+    };
+
+    assert_eq!(status, block.status);
+    assert_eq!(block_hash, block.block_hash);
+    assert_eq!(parent_hash, block.parent_hash);
+    assert_eq!(block_number, block.block_number);
+    assert_eq!(new_root, block.new_root);
+    assert_eq!(timestamp, block.timestamp);
+    assert_eq!(sequencer_address, block.sequencer_address);
+    assert_eq!(l1_gas_price, block.l1_gas_price);
+    assert_eq!(starknet_version, block.starknet_version);
+
+    block
+        .transactions
+        .iter()
+        .map(|tx| tx.transaction_hash().to_owned())
+        .zip(transactions)
+        .for_each(|(expected, actual)| assert_eq!(actual, expected));
+}
+
+#[tokio::test]
+async fn test_get_class() {
+    let TestContext { client, block: _, block_id, extracted_value } =
+        context(|block| {
+            block.transactions.iter().find_map(
+                |transaction| match transaction {
+                    Transaction::Declare(DeclareTransaction::V0(declare)) => {
+                        Some(declare.class_hash)
+                    }
+                    Transaction::Declare(DeclareTransaction::V1(declare)) => {
+                        Some(declare.class_hash)
+                    }
+                    Transaction::Declare(DeclareTransaction::V2(declare)) => {
+                        Some(declare.class_hash)
+                    }
+                    Transaction::Declare(DeclareTransaction::V3(declare)) => {
+                        Some(declare.class_hash)
+                    }
+                    _ => None,
+                },
+            )
+        })
+        .await;
+
+    client.get_class(block_id, extracted_value).await.expect("getClass failed");
+}
+
+#[tokio::test]
+async fn test_get_class_at() {
+    let TestContext {
+        client,
+        block: _,
+        block_id,
+        extracted_value: deploy_tx_hash,
+    } = context(|block| {
+        block.transactions.iter().find_map(|transaction| match transaction {
+            Transaction::DeployAccount(DeployAccountTransaction::V3(
+                deploy,
+            )) => Some(deploy.transaction_hash),
+            _ => None,
+        })
+    })
+    .await;
+
+    let receipt = match client
+        .get_transaction_receipt(deploy_tx_hash)
+        .await
+        .expect("the transaction to have a matching receipt")
+    {
+        MaybePendingTransactionReceipt::Receipt(
+            TransactionReceipt::DeployAccount(receipt),
+        ) => receipt,
+        _ => panic!("Expected a valid receipt, got a pending one"),
+    };
+
+    client
+        .get_class_at(block_id, receipt.contract_address)
+        .await
+        .expect("getClass failed");
+}
+
+#[tokio::test]
+async fn test_get_class_hash_at() {
+    let TestContext {
+        client,
+        block: _,
+        block_id,
+        extracted_value: deploy_tx_hash,
+    } = context(|block| {
+        block.transactions.iter().find_map(|transaction| match transaction {
+            Transaction::DeployAccount(DeployAccountTransaction::V3(
+                deploy,
+            )) => Some(deploy.transaction_hash),
+            _ => None,
+        })
+    })
+    .await;
+
+    let receipt = match client
+        .get_transaction_receipt(deploy_tx_hash)
+        .await
+        .expect("the transaction to have a matching receipt")
+    {
+        MaybePendingTransactionReceipt::Receipt(
+            TransactionReceipt::DeployAccount(receipt),
+        ) => receipt,
+        _ => panic!("Expected a valid receipt, got a pending one"),
+    };
+
+    client
+        .get_class_hash_at(block_id, receipt.contract_address)
+        .await
+        .expect("getClass failed");
+}
+
+#[tokio::test]
+async fn test_get_nonce() {
+    let TestContext {
+        client,
+        block: _,
+        block_id,
+        extracted_value: (original_nonce, sender),
+    } = context(|block| {
+        // Browse the transaction in reverse order to make sure we got the latest nonce.
+        block.transactions.iter().rev().find_map(
+            |transaction| match transaction {
+                Transaction::Invoke(InvokeTransaction::V1(invoke)) => {
+                    Some((invoke.nonce, invoke.sender_address))
+                }
+                Transaction::Invoke(InvokeTransaction::V3(invoke)) => {
+                    Some((invoke.nonce, invoke.sender_address))
+                }
+                _ => None,
+            },
+        )
+    })
+    .await;
+    let original_nonce = truncate_felt_to_u128(&original_nonce);
+
+    let incremented_nonce =
+        client.get_nonce(block_id, sender).await.expect("getNonce failed");
+    let incremented_nonce = truncate_felt_to_u128(&incremented_nonce);
+
+    assert_eq!(original_nonce + 1, incremented_nonce);
+}
+
+#[tokio::test]
+async fn test_get_transaction_by_block_id_and_index() {
+    let txs = 10;
+    let TestContext { client, block, block_id, extracted_value: () } =
+        n_txs_context(txs).await;
+
+    async fn check_transaction(
+        client: &JsonRpcClient<HttpTransport>,
+        block_id: BlockId,
+        transaction_index: usize,
+        expected: &BlockWithTxs,
+    ) {
+        let transaction = client.get_transaction_by_block_id_and_index(block_id, transaction_index as u64).await.expect("Failed to retrieve a specific transaction by its block ID and index");
+
+        // `starknet-rs` doesn't implement `PartialEq` on its DTOs, and transactions have many *variants which makes pure Rust comparison painful.
+        // Just serialize these to compare them.
+        pretty_assertions::assert_eq!(
+            serde_json::to_value(&transaction).unwrap(),
+            serde_json::to_value(&expected.transactions[transaction_index])
+                .unwrap(),
+        )
+    }
+
+    for transaction_index in 0..txs {
+        check_transaction(&client, block_id, transaction_index, &block).await;
+    }
+
+    check_transaction(&client, block_id, block.transactions.len() - 1, &block)
+        .await;
+}
+
+#[tokio::test]
+async fn test_get_transaction_by_hash() {
+    let txs = 10;
+    let TestContext { client, block, block_id: _, extracted_value: () } =
+        n_txs_context(txs).await;
+
+    async fn check_transaction(
+        client: &JsonRpcClient<HttpTransport>,
+        expected: &Transaction,
+    ) {
+        let transaction = client.get_transaction_by_hash(expected.transaction_hash()).await.expect("Failed to retrieve a specific transaction by its block ID and index");
+
+        // `starknet-rs` doesn't implement `PartialEq` on its DTOs, and transactions have many *variants which makes pure Rust comparison painful.
+        // Just serialize these to compare them.
+        pretty_assertions::assert_eq!(
+            serde_json::to_value(&transaction).unwrap(),
+            serde_json::to_value(&expected).unwrap(),
+        )
+    }
+
+    for transaction_index in 0..txs {
+        check_transaction(&client, &block.transactions[transaction_index])
+            .await;
+    }
+
+    check_transaction(
+        &client,
+        block
+            .transactions
+            .last()
+            .as_ref()
+            .expect("We need a last transaction here"),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_get_transaction_status() {
+    let txs = 10;
+    let TestContext { client, block, block_id: _, extracted_value: () } =
+        n_txs_context(txs).await;
+
+    async fn check_transaction(
+        client: &JsonRpcClient<HttpTransport>,
+        transaction_hash: FieldElement,
+    ) {
+        let _status = client
+            .get_transaction_status(transaction_hash)
+            .await
+            .expect("Failed to retrieve the transaction status");
+    }
+
+    for transaction_index in 0..txs {
+        check_transaction(
+            &client,
+            *block.transactions[transaction_index].transaction_hash(),
+        )
+        .await;
+    }
+
+    check_transaction(
+        &client,
+        *block
+            .transactions
+            .last()
+            .as_ref()
+            .expect("We need a last transaction here")
+            .transaction_hash(),
+    )
+    .await;
+}
+
+/* TODO
+   Add more test scenarios to cover the following methods:
+
+   starknet_block_hash_and_number
+   starknet_call
+   starknet_estimateFee
+   starknet_estimateFeeSingle
+   starknet_getBalance
+   starknet_getEvents
+   starknet_getProof
+   starknet_getStateRoot
+   starknet_getStateUpdate
+   starknet_getStorateAt
+   starknet_getTransactionReceipt
+   starknet_getTransactionStatus
+   starknet_syncing
+   pathfinder_getProof
+*/
+
+fn truncate_felt_to_u128(felt: &FieldElement) -> u128 {
+    u128::from_be_bytes(felt.to_bytes_be()[16..].try_into().unwrap())
+}


### PR DESCRIPTION
Re-implement the simplest Hurl-based test scenarios in rust

Create a new workflow for these tests: rust-integration-tests
Rename the old workflow to hurl-integration-tests

The new test suite only covers 11 scenarios out of 25 for now.

This new workflow still isn't as reliable as I'd want it to be. From what I can tell, Helios just fail to synchronize sometimes. It's nothing new. This will be my next area of focus.