### PR TITLE
Bring support for the Starknet OpenRPC v0.6.0 spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           BEERUS_VERSION: "ci"
           NETWORK: "mainnet"
           ETH_EXECUTION_RPC: ${{ secrets.ETH_EXECUTION_RPC_MAINNET }}
-          STARKNET_RPC: ${{ secrets.STARKNET_RPC_MAINNET }}
+          STARKNET_RPC: ${{ secrets.STARKNET_RPC_0_6_0_MAINNET }}
         run: ./target/release/beerus &
 
       - name: run integration test on MAINNET

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "beerus-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "beerus-core",
  "beerus-rpc",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "beerus-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aquamarine",
  "async-trait",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "beerus-rpc"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "beerus-core",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4778,13 +4778,13 @@ dependencies = [
 
 [[package]]
 name = "starknet"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0623b045f3dc10aef030c9ddd4781cff9cbe1188b71063cc510b75d1f96be6"
+checksum = "36f8002bf3d750dd2c0434aca8b5e88e2438cd6c452f4c18f34d0a8a9f42cb1a"
 dependencies = [
  "starknet-accounts",
  "starknet-contract",
- "starknet-core 0.6.1",
+ "starknet-core",
  "starknet-crypto",
  "starknet-ff",
  "starknet-macros",
@@ -4794,13 +4794,13 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.5.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e97edc480348dca300e5a8234e6c4e6f2f1ac028f2b16fcce294ebe93d07f4"
+checksum = "e8e39a5807a735343493781dd5e640c4af838de470b0a73f420bed642fdc2ff1"
 dependencies = [
  "async-trait",
  "auto_impl",
- "starknet-core 0.6.1",
+ "starknet-core",
  "starknet-providers",
  "starknet-signers",
  "thiserror",
@@ -4808,35 +4808,17 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.5.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b86e3f6b3ca9a5c45271ab10871c99f7dc82fee3199d9f8c7baa2a1829947d"
+checksum = "b4996991356cd0e9499c663680eba7e77de4109e4995f652c1608899a65c09ee"
 dependencies = [
  "serde",
  "serde_json",
  "serde_with",
  "starknet-accounts",
- "starknet-core 0.6.1",
+ "starknet-core",
  "starknet-providers",
  "thiserror",
-]
-
-[[package]]
-name = "starknet-core"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14139b1c39bdc2f1e663c12090ff5108fe50ebe62c09e15e32988dfaf445a7e4"
-dependencies = [
- "base64 0.21.7",
- "flate2",
- "hex",
- "serde",
- "serde_json",
- "serde_json_pythonic",
- "serde_with",
- "sha3",
- "starknet-crypto",
- "starknet-ff",
 ]
 
 [[package]]
@@ -4918,15 +4900,15 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5d2964612f0ccd0a700279e33cfc98d6db04f64645ff834f3b7ec422142d7a"
 dependencies = [
- "starknet-core 0.9.0",
+ "starknet-core",
  "syn 2.0.48",
 ]
 
 [[package]]
 name = "starknet-providers"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b136c26b72ff1756f0844e0aa80bab680ceb99d63921826facbb8e7340ff82"
+checksum = "6a4bd1c262936543d6d14d299f476585e8c9625a4e284d9255b54f1c2e68e64a"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -4937,23 +4919,23 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-core 0.6.1",
+ "starknet-core",
  "thiserror",
  "url",
 ]
 
 [[package]]
 name = "starknet-signers"
-version = "0.4.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9386015d2e6dc3df285bfb33a3afd8ad7596c70ed38ab57019de4d2dfc7826f"
+checksum = "8c5eb659e66b56ceafb9025cd601226d8f34d273f1b826cd4053ab6333ff0898"
 dependencies = [
  "async-trait",
  "auto_impl",
  "crypto-bigint",
  "eth-keystore",
  "rand 0.8.5",
- "starknet-core 0.6.1",
+ "starknet-core",
  "starknet-crypto",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ tokio = { version = "1", features = ["sync", "macros", "io-util", "rt", "time"] 
 eyre = "0.6.8"
 serde = "1.0.156"
 serde_with = "2.3.3"
-starknet = "0.6.0"
+starknet = "0.9.0"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.17"

--- a/README.md
+++ b/README.md
@@ -16,39 +16,47 @@
 
 ## News
 
+* 29/02/24: Migrate to the [Starknet v0.6.0 OpenRPC spec](https://github.com/starkware-libs/starknet-specs/tree/v0.6.0), release Beerus v0.4.0
 * 17/01/24: [Eiger is taking over Beerus!](https://www.eiger.co/blog/eiger-taking-over-ownership-for-beerus-working-on-starknet-light-clients)
 
 ## Getting Started
 
-```bash
-cargo build --release
+### Configuration
 
-# insert valid api keys
-./target/release/beerus -c etc/conf/beerus.json
+Beerus relies on TWO untrusted RPC endpoints, one for L1 (Ethereum), and one for L2 (Starknet). 
+As these are untrusted they will typically not be nodes run on your local host or your local network.
 
-# wait for server to start
-hurl etc/rpc/starknet_getStateRoot.hurl
-```
+Beerus requires the [v0.6.0 of the Starknet OpenRPC specs](https://github.com/starkware-libs/starknet-specs/tree/v0.6.0).
 
-### Config
+These untrusted RPC providers must adhere to both the L1 `eth_getProof` endpoint
+as well as the L2 `pathfinder_getProof` endpoint ([detailed instructions needed!](https://github.com/eigerco/beerus/issues/602)).For this we recommend using
+[Alchemy](https://docs.alchemy.com/reference/starknet-api-faq#what-versions-of-starknet-api-are-supported) as your untrusted L2 node provider. 
 
-Beerus relies on TWO untrusted RPC endpoints. As these are untrusted they will
-typically not be nodes run on your local host or your local network. These 
-untrusted RPC providers must adhere to both the L1 `eth_getProof` endpoint
-as well as the L2 `pathfinder_getProof` endpoint. For this we recommend using
-[Alchemy](https://www.alchemy.com) as your untrusted L2 node provider. 
+More API providers can be found [here](https://docs.starknet.io/documentation/tools/api-services/).
 
-*NOTE: we rely on helios for both valid checkpoint values and consensus rpc urls*
+*NOTE: we rely on [helios](https://github.com/a16z/helios) for both valid checkpoint values and consensus rpc urls*
 
 | field   | example | description |
 | ----------- | ----------- | ----------- |
 | network | MAINNET or GOERLI | network to query |
 | eth_execution_rpc | https://eth-mainnet.g.alchemy.com/v2/YOURAPIKEY | untrusted l1 node provider url |
-| starknet_rpc | https://starknet-mainnet.g.alchemy.com/v2/YOURAPIKEY | untrusted l2 node provider url |
+| starknet_rpc | https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.6/YOURAPIKEY | untrusted l2 node provider url |
 | data_dir | tmp | `OPTIONAL` location to store both l1 and l2 data |
 | poll_secs | 5 | `OPTIONAL` seconds to wait for querying sn state |
 | rpc_addr | 127.0.0.1:3030 | `OPTIONAL` local address to listen for rpc reqs |
 | fee_token_addr | 0x049d36...e004dc7 | `OPTIONAL` fee token to check for `getBalance` |
+
+### Running Beerus for the first time
+
+Copy the configuration file from `etc/conf/beerus.toml` and set up the API provider URLs in the copy.
+
+Then run:
+```bash
+cargo run --release -- -c ./path/to/config.toml
+
+# Once Beerus has started, 
+hurl etc/rpc/starknet_getStateRoot.hurl
+```
 
 ## Development
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -2,7 +2,7 @@
 description = "CLI for the Beerus Light Client"
 edition = "2021"
 name = "beerus-cli"
-version = "0.3.0"
+version = "0.4.0"
 
 [[bin]]
 name = "beerus"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Core utilities for the Beerus Light Client"
 edition = "2021"
 name = "beerus-core"
-version = "0.3.0"
+version = "0.4.0"
 
 [package.metadata.cargo-udeps]
 # Aquamarine generates Mermaid diagrams and causes a udeps false positive.

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -2,7 +2,7 @@
 description = "JSON-RPC server for the Beerus Light Client"
 edition = "2021"
 name = "beerus-rpc"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 beerus-core = { path = "../core" }

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -2,83 +2,214 @@ use beerus_core::CoreError;
 use eyre::Report;
 use jsonrpsee::types::ErrorObjectOwned;
 use starknet::core::types::StarknetError;
-use starknet::providers::jsonrpc::{HttpTransportError, JsonRpcClientError};
-use starknet::providers::{MaybeUnknownErrorCode, ProviderError};
+use starknet::providers::ProviderError;
+use starknet::providers::ProviderError::StarknetError as StarknetProviderError;
 
 #[derive(Debug)]
 pub enum BeerusRpcError {
-    Provider(ProviderError<JsonRpcClientError<HttpTransportError>>),
+    Provider(ProviderError),
     Other((i32, String)),
 }
 
 impl From<BeerusRpcError> for ErrorObjectOwned {
     fn from(err: BeerusRpcError) -> Self {
         match err {
-            BeerusRpcError::Provider(e) => {
-                match e {
-                    ProviderError::StarknetError(e) => {
-                        let (code, message) = (e.code, e.message);
-                        let code = match code {
-                        MaybeUnknownErrorCode::Known(known) => match known {
-                            StarknetError::FailedToReceiveTransaction => 1,
-                            StarknetError::ContractNotFound => 20,
-                            StarknetError::BlockNotFound => 24,
-                            StarknetError::InvalidTransactionIndex => 27,
-                            StarknetError::ClassHashNotFound => 28,
-                            StarknetError::TransactionHashNotFound => 29,
-                            StarknetError::PageSizeTooBig => 31,
-                            StarknetError::NoBlocks => 32,
-                            StarknetError::InvalidContinuationToken => 33,
-                            StarknetError::TooManyKeysInFilter => 34,
-                            StarknetError::ContractError => 40,
-                            StarknetError::ClassAlreadyDeclared => 51,
-                            StarknetError::InvalidTransactionNonce => 52,
-                            StarknetError::InsufficientMaxFee => 53,
-                            StarknetError::InsufficientAccountBalance => 54,
-                            StarknetError::ValidationFailure => 55,
-                            StarknetError::CompilationFailed => 56,
-                            StarknetError::ContractClassSizeIsTooLarge => 57,
-                            StarknetError::NonAccount => 58,
-                            StarknetError::DuplicateTx => 59,
-                            StarknetError::CompiledClassHashMismatch => 60,
-                            StarknetError::UnsupportedTxVersion => 61,
-                            StarknetError::UnsupportedContractClassVersion => 62,
-                            StarknetError::UnexpectedError => 63,
-                        },
-                        MaybeUnknownErrorCode::Unknown(unknown) => unknown as i32,
-                    };
-                        ErrorObjectOwned::owned(code, message, None::<()>)
+            BeerusRpcError::Provider(provider_err) => match provider_err {
+                StarknetProviderError(sn_err) => match &sn_err {
+                    StarknetError::FailedToReceiveTransaction => {
+                        ErrorObjectOwned::owned(1, sn_err.message(), None::<()>)
                     }
-                    _ => ErrorObjectOwned::owned(
-                        -32601,
-                        format!("{e}"),
+                    StarknetError::ContractNotFound => ErrorObjectOwned::owned(
+                        20,
+                        sn_err.message(),
                         None::<()>,
                     ),
-                }
-            }
-            BeerusRpcError::Other((code, message)) => {
-                ErrorObjectOwned::owned(code, message, None::<()>)
+                    StarknetError::BlockNotFound => ErrorObjectOwned::owned(
+                        24,
+                        sn_err.message(),
+                        None::<()>,
+                    ),
+                    StarknetError::InvalidTransactionIndex => {
+                        ErrorObjectOwned::owned(
+                            27,
+                            sn_err.message(),
+                            None::<()>,
+                        )
+                    }
+                    StarknetError::ClassHashNotFound => {
+                        ErrorObjectOwned::owned(
+                            28,
+                            sn_err.message(),
+                            None::<()>,
+                        )
+                    }
+                    StarknetError::TransactionHashNotFound => {
+                        ErrorObjectOwned::owned(
+                            29,
+                            sn_err.message(),
+                            None::<()>,
+                        )
+                    }
+                    StarknetError::PageSizeTooBig => ErrorObjectOwned::owned(
+                        31,
+                        sn_err.message(),
+                        None::<()>,
+                    ),
+                    StarknetError::NoBlocks => ErrorObjectOwned::owned(
+                        32,
+                        sn_err.message(),
+                        None::<()>,
+                    ),
+                    StarknetError::InvalidContinuationToken => {
+                        ErrorObjectOwned::owned(
+                            33,
+                            sn_err.message(),
+                            None::<()>,
+                        )
+                    }
+                    StarknetError::TooManyKeysInFilter => {
+                        ErrorObjectOwned::owned(
+                            34,
+                            sn_err.message(),
+                            None::<()>,
+                        )
+                    }
+                    StarknetError::ContractError(data) => {
+                        ErrorObjectOwned::owned(
+                            40,
+                            sn_err.message(),
+                            Some(data),
+                        )
+                    }
+                    StarknetError::TransactionExecutionError(data) => {
+                        ErrorObjectOwned::owned(
+                            41,
+                            sn_err.message(),
+                            Some(data),
+                        )
+                    }
+                    StarknetError::ClassAlreadyDeclared => {
+                        ErrorObjectOwned::owned(
+                            51,
+                            sn_err.message(),
+                            None::<()>,
+                        )
+                    }
+                    StarknetError::InvalidTransactionNonce => {
+                        ErrorObjectOwned::owned(
+                            51,
+                            sn_err.message(),
+                            None::<()>,
+                        )
+                    }
+                    StarknetError::InsufficientMaxFee => {
+                        ErrorObjectOwned::owned(
+                            53,
+                            sn_err.message(),
+                            None::<()>,
+                        )
+                    }
+                    StarknetError::InsufficientAccountBalance => {
+                        ErrorObjectOwned::owned(
+                            54,
+                            sn_err.message(),
+                            None::<()>,
+                        )
+                    }
+                    StarknetError::ValidationFailure(data) => {
+                        ErrorObjectOwned::owned(
+                            55,
+                            sn_err.message(),
+                            Some(data),
+                        )
+                    }
+                    StarknetError::CompilationFailed => {
+                        ErrorObjectOwned::owned(
+                            56,
+                            sn_err.message(),
+                            None::<()>,
+                        )
+                    }
+                    StarknetError::ContractClassSizeIsTooLarge => {
+                        ErrorObjectOwned::owned(
+                            57,
+                            sn_err.message(),
+                            None::<()>,
+                        )
+                    }
+                    StarknetError::NonAccount => ErrorObjectOwned::owned(
+                        58,
+                        sn_err.message(),
+                        None::<()>,
+                    ),
+                    StarknetError::DuplicateTx => ErrorObjectOwned::owned(
+                        59,
+                        sn_err.message(),
+                        None::<()>,
+                    ),
+                    StarknetError::CompiledClassHashMismatch => {
+                        ErrorObjectOwned::owned(
+                            60,
+                            sn_err.message(),
+                            None::<()>,
+                        )
+                    }
+                    StarknetError::UnsupportedTxVersion => {
+                        ErrorObjectOwned::owned(
+                            61,
+                            sn_err.message(),
+                            None::<()>,
+                        )
+                    }
+                    StarknetError::UnsupportedContractClassVersion => {
+                        ErrorObjectOwned::owned(
+                            62,
+                            sn_err.message(),
+                            None::<()>,
+                        )
+                    }
+                    StarknetError::UnexpectedError(data) => {
+                        ErrorObjectOwned::owned(
+                            63,
+                            sn_err.message(),
+                            Some(data),
+                        )
+                    }
+                    StarknetError::NoTraceAvailable(data) => {
+                        ErrorObjectOwned::owned(
+                            10,
+                            sn_err.message(),
+                            Some(data),
+                        )
+                    }
+                },
+                _ => ErrorObjectOwned::owned(
+                    -32601,
+                    format!("{provider_err}"),
+                    None::<()>,
+                ),
+            },
+            BeerusRpcError::Other(other_err) => {
+                ErrorObjectOwned::owned(other_err.0, other_err.1, None::<()>)
             }
         }
     }
 }
 
-impl From<ProviderError<JsonRpcClientError<HttpTransportError>>>
-    for BeerusRpcError
-{
-    fn from(e: ProviderError<JsonRpcClientError<HttpTransportError>>) -> Self {
-        BeerusRpcError::Provider(e)
+impl From<ProviderError> for BeerusRpcError {
+    fn from(err: ProviderError) -> Self {
+        BeerusRpcError::Provider(err)
     }
 }
 
 impl From<CoreError> for BeerusRpcError {
-    fn from(e: CoreError) -> Self {
-        BeerusRpcError::Other((-32601, format!("{e}")))
+    fn from(err: CoreError) -> Self {
+        BeerusRpcError::Other((-32601, format!("{err}")))
     }
 }
 
 impl From<Report> for BeerusRpcError {
-    fn from(e: Report) -> Self {
-        BeerusRpcError::Other((-32601, format!("{e}")))
+    fn from(err: Report) -> Self {
+        BeerusRpcError::Other((-32601, format!("{err}")))
     }
 }

--- a/etc/conf/beerus.toml
+++ b/etc/conf/beerus.toml
@@ -3,4 +3,4 @@ eth_execution_rpc = "https://eth-mainnet.g.alchemy.com/v2/<YOUR API KEY>"
 starknet_rpc = "https://starknet-mainnet.g.alchemy.com/v2/<YOUR API KEY>"
 data_dir = "tmp"
 poll_secs = 5
-rpc_addr = "127.0.0.1:8080"
+rpc_addr = "127.0.0.1:3030"


### PR DESCRIPTION
Beerus is currently implicitly tied to the Starknet OpenRPC v0.5.1 spec. This PR upgrades the requirement to v0.6.0 and makes it more explicit in the README.md file. 

This is a breaking change. I bumped the Beerus version to v0.4.0 in this PR.

See #599 for more details about the motivation.

Commits will be squashed before merging.