### PR TITLE
fix: Make getEvents comply with the OpenRPC spec

### DIFF
--- a/crates/rpc/src/api.rs
+++ b/crates/rpc/src/api.rs
@@ -9,8 +9,8 @@ use starknet::core::types::{
     BlockHashAndNumber, BlockId, BroadcastedDeclareTransaction,
     BroadcastedDeployAccountTransaction, BroadcastedInvokeTransaction,
     BroadcastedTransaction, ContractClass, DeclareTransactionResult,
-    DeployAccountTransactionResult, EventFilter, EventsPage, FeeEstimate,
-    FieldElement, FunctionCall, InvokeTransactionResult,
+    DeployAccountTransactionResult, EventFilterWithPage, EventsPage,
+    FeeEstimate, FieldElement, FunctionCall, InvokeTransactionResult,
     MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
     MaybePendingStateUpdate, MaybePendingTransactionReceipt, MsgFromL1,
     SimulationFlagForEstimateFee, SyncStatusType, Transaction,
@@ -157,9 +157,7 @@ pub trait BeerusRpc {
     #[method(name = "getEvents")]
     async fn get_events(
         &self,
-        filter: EventFilter,
-        continuation_token: Option<String>,
-        chunk_size: u64,
+        filter: EventFilterWithPage,
     ) -> Result<EventsPage, BeerusRpcError>;
 
     #[method(name = "getNonce")]
@@ -465,13 +463,15 @@ impl BeerusRpcServer for BeerusRpc {
 
     async fn get_events(
         &self,
-        filter: EventFilter,
-        continuation_token: Option<String>,
-        chunk_size: u64,
+        filter: EventFilterWithPage,
     ) -> Result<EventsPage, BeerusRpcError> {
         self.beerus
             .starknet_client
-            .get_events(filter, continuation_token, chunk_size)
+            .get_events(
+                filter.event_filter,
+                filter.result_page_request.continuation_token,
+                filter.result_page_request.chunk_size,
+            )
             .await
             .map_err(BeerusRpcError::from)
     }

--- a/etc/rpc/mainnet/starknet_getEvents.hurl
+++ b/etc/rpc/mainnet/starknet_getEvents.hurl
@@ -21,9 +21,9 @@ Content-Type: application/json
                     "0x599573a0023b0ce23bb8537d2c5f3e9b72ebd4f008d033b4c0a1475a68338ac",
                     "0x47a4c36c2932f213e7b054c9573e49a6681d5b710d1b25a96ea6346f5689929"
                 ]
-            ]
-        },
-        "chunk_size": 1
+            ],
+            "chunk_size": 1
+        }
     },
     "id": 0
 }


### PR DESCRIPTION
Our `starknet_getEvents` signature differs from the spec.

The spec has a single "filter" parameter including the actual filter parameters as well as the paging parameters.
Our implementation separates both.
This PR brings our implementation closer to the spec.

[Method spec](https://github.com/starkware-libs/starknet-specs/blob/v0.6.0/api/starknet_api_openrpc.json#L768C9-L814C11):
```json
{
            "name": "starknet_getEvents",
            "summary": "Returns all events matching the given filter",
            "description": "Returns all event objects matching the conditions in the provided filter",
            "params": [
                {
                    "name": "filter",
                    "summary": "The conditions used to filter the returned events",
                    "required": true,
                    "schema": {
                        "title": "Events request",
                        "allOf": [
                            {
                                "title": "Event filter",
                                "$ref": "#/components/schemas/EVENT_FILTER"
                            },
                            {
                                "title": "Result page request",
                                "$ref": "#/components/schemas/RESULT_PAGE_REQUEST"
                            }
                        ]
                    }
                }
            ],
            "result": {
                "name": "events",
                "description": "All the event objects matching the filter",
                "schema": {
                    "title": "Events chunk",
                    "$ref": "#/components/schemas/EVENTS_CHUNK"
                }
            },
            "errors": [
                {
                    "$ref": "#/components/errors/PAGE_SIZE_TOO_BIG"
                },
                {
                    "$ref": "#/components/errors/INVALID_CONTINUATION_TOKEN"
                },
                {
                    "$ref": "#/components/errors/BLOCK_NOT_FOUND"
                },
                {
                    "$ref": "#/components/errors/TOO_MANY_KEYS_IN_FILTER"
                }
            ]
        },
```

