### PR TITLE
chore: bump helios to 0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,8 +1527,8 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "client"
-version = "0.5.4"
-source = "git+https://github.com/a16z/helios?tag=0.5.4#ba3364394a013dae3275b60438c9d7a7736d7fe3"
+version = "0.5.5"
+source = "git+https://github.com/a16z/helios?tag=0.5.5#c8f5a4d623ec90df2d3ceb9490b8aaa48179e94f"
 dependencies = [
  "common",
  "config",
@@ -1620,8 +1620,8 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.5.4"
-source = "git+https://github.com/a16z/helios?tag=0.5.4#ba3364394a013dae3275b60438c9d7a7736d7fe3"
+version = "0.5.5"
+source = "git+https://github.com/a16z/helios?tag=0.5.5#c8f5a4d623ec90df2d3ceb9490b8aaa48179e94f"
 dependencies = [
  "ethers",
  "eyre",
@@ -1633,8 +1633,8 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.5.4"
-source = "git+https://github.com/a16z/helios?tag=0.5.4#ba3364394a013dae3275b60438c9d7a7736d7fe3"
+version = "0.5.5"
+source = "git+https://github.com/a16z/helios?tag=0.5.5#c8f5a4d623ec90df2d3ceb9490b8aaa48179e94f"
 dependencies = [
  "common",
  "dirs 4.0.0",
@@ -1655,8 +1655,8 @@ dependencies = [
 
 [[package]]
 name = "consensus"
-version = "0.5.4"
-source = "git+https://github.com/a16z/helios?tag=0.5.4#ba3364394a013dae3275b60438c9d7a7736d7fe3"
+version = "0.5.5"
+source = "git+https://github.com/a16z/helios?tag=0.5.5#c8f5a4d623ec90df2d3ceb9490b8aaa48179e94f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2570,8 +2570,8 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "execution"
-version = "0.5.4"
-source = "git+https://github.com/a16z/helios?tag=0.5.4#ba3364394a013dae3275b60438c9d7a7736d7fe3"
+version = "0.5.5"
+source = "git+https://github.com/a16z/helios?tag=0.5.5#c8f5a4d623ec90df2d3ceb9490b8aaa48179e94f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3086,8 +3086,8 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "helios"
-version = "0.5.4"
-source = "git+https://github.com/a16z/helios?tag=0.5.4#ba3364394a013dae3275b60438c9d7a7736d7fe3"
+version = "0.5.5"
+source = "git+https://github.com/a16z/helios?tag=0.5.5#c8f5a4d623ec90df2d3ceb9490b8aaa48179e94f"
 dependencies = [
  "client",
  "common",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,7 +16,7 @@ bitvec = "1.0.1"
 ethabi = "18.0.0"
 ethers = "2.0.11"
 eyre.workspace = true
-helios = { git = "https://github.com/a16z/helios", tag = "0.5.4" }
+helios = { git = "https://github.com/a16z/helios", tag = "0.5.5" }
 reqwest = { version = "0.11.16", default-features = false, features = ["rustls-tls"] }
 serde = { workspace = true, features = ["derive"] }
 serde_with.workspace = true


### PR DESCRIPTION
Helios 0.5.5 is required after Dencun update of the Ethereum mainnet.

Before (helios 0.5.4):

```
$ ./target/release/beerus -c tmp/beerus.toml
2024-03-13T21:46:40.537298Z  INFO beerus: init beerus client: MAINNET
2024-03-13T21:46:48.701516Z ERROR helios::consensus: sync failed err=invalid sync committee signature
```

After (helios 0.5.5):

```
$ ./target/release/beerus -c tmp/beerus.toml
2024-03-13T21:47:37.953161Z  INFO beerus: init beerus client: MAINNET
2024-03-13T21:47:44.324038Z  INFO helios::consensus: updated head               slot=8628535  confidence=98.63%  age=00:00:00:21
2024-03-13T21:47:44.947012Z  INFO helios::consensus: consensus client in sync with checkpoint: 0xede690aba0b6caf9213c2c32928d16baae51aa9644d76bfe65aa21f657663222
2024-03-13T21:47:50.599135Z  INFO beerus: Beerus JSON-RPC server started 🚀: http://127.0.0.1:3030
2024-03-13T21:47:54.164994Z  INFO beerus_core::client: L1 block: 609684, L2 block: 611951 (L1 is 2267 blocks behind)
2024-03-13T21:47:54.165061Z  INFO beerus_core::client: synced block: 611951
2024-03-13T21:48:05.683006Z  INFO helios::consensus: updated head               slot=8628536  confidence=98.44%  age=00:00:00:30
2024-03-13T21:48:06.363244Z  INFO helios::consensus: updated head               slot=8628537  confidence=98.63%  age=00:00:00:19
...
```