### PR TITLE
Add `SEPOLIA` network configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,7 +1536,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 [[package]]
 name = "client"
 version = "0.5.5"
-source = "git+https://github.com/a16z/helios?tag=0.5.5#c8f5a4d623ec90df2d3ceb9490b8aaa48179e94f"
+source = "git+https://github.com/a16z/helios?rev=5ee0477#5ee0477b8c0b86d695bf1589b32bbc7d12e1a324"
 dependencies = [
  "common",
  "config",
@@ -1629,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.5.5"
-source = "git+https://github.com/a16z/helios?tag=0.5.5#c8f5a4d623ec90df2d3ceb9490b8aaa48179e94f"
+source = "git+https://github.com/a16z/helios?rev=5ee0477#5ee0477b8c0b86d695bf1589b32bbc7d12e1a324"
 dependencies = [
  "ethers",
  "eyre",
@@ -1642,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.5.5"
-source = "git+https://github.com/a16z/helios?tag=0.5.5#c8f5a4d623ec90df2d3ceb9490b8aaa48179e94f"
+source = "git+https://github.com/a16z/helios?rev=5ee0477#5ee0477b8c0b86d695bf1589b32bbc7d12e1a324"
 dependencies = [
  "common",
  "dirs 4.0.0",
@@ -1664,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "consensus"
 version = "0.5.5"
-source = "git+https://github.com/a16z/helios?tag=0.5.5#c8f5a4d623ec90df2d3ceb9490b8aaa48179e94f"
+source = "git+https://github.com/a16z/helios?rev=5ee0477#5ee0477b8c0b86d695bf1589b32bbc7d12e1a324"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2579,7 +2579,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "execution"
 version = "0.5.5"
-source = "git+https://github.com/a16z/helios?tag=0.5.5#c8f5a4d623ec90df2d3ceb9490b8aaa48179e94f"
+source = "git+https://github.com/a16z/helios?rev=5ee0477#5ee0477b8c0b86d695bf1589b32bbc7d12e1a324"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3095,7 +3095,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 [[package]]
 name = "helios"
 version = "0.5.5"
-source = "git+https://github.com/a16z/helios?tag=0.5.5#c8f5a4d623ec90df2d3ceb9490b8aaa48179e94f"
+source = "git+https://github.com/a16z/helios?rev=5ee0477#5ee0477b8c0b86d695bf1589b32bbc7d12e1a324"
 dependencies = [
  "client",
  "common",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,8 +16,7 @@ bitvec = "1.0.1"
 ethabi = "18.0.0"
 ethers = "2.0.11"
 eyre.workspace = true
-## TODO: This PR is needed: https://github.com/a16z/helios/pull/326
-helios = { git = "https://github.com/a16z/helios", tag = "0.5.5" }
+helios = { git = "https://github.com/a16z/helios", rev = "5ee0477" }
 reqwest = { version = "0.11.16", default-features = false, features = ["rustls-tls"] }
 serde = { workspace = true, features = ["derive"] }
 serde_with.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,6 +16,7 @@ bitvec = "1.0.1"
 ethabi = "18.0.0"
 ethers = "2.0.11"
 eyre.workspace = true
+## TODO: This PR is needed: https://github.com/a16z/helios/pull/326
 helios = { git = "https://github.com/a16z/helios", tag = "0.5.5" }
 reqwest = { version = "0.11.16", default-features = false, features = ["rustls-tls"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -204,7 +204,7 @@ impl BeerusClient {
                         info!("synced block: {block_number}")
                     }
                     Ok(None) => debug!("already at head block"),
-                    Err(e) => error!("failed to pull block: {e}"),
+                    Err(e) => error!("sync error: {e}"),
                 };
                 debug!("state loop: delay {poll_interval:?}");
                 thread::sleep(poll_interval);
@@ -332,11 +332,11 @@ async fn sync(
     let starknet_state_root =
         get_starknet_state_root(l1_client, core_contract_addr)
             .await
-            .context("starknet state root")?;
+            .context("failed to get starknet state root")?;
     let l1_starknet_block_number =
         get_starknet_state_block_number(l1_client, core_contract_addr)
             .await
-            .context("starknet state block")?;
+            .context("failed to get starknet block")?;
     let local_block_number = node.read().await.l1_block_number;
 
     debug!("starknet block number: {l1_starknet_block_number}, local block number: {local_block_number}");
@@ -349,7 +349,7 @@ async fn sync(
     match l2_client
         .get_block_with_tx_hashes(BlockId::Tag(StarknetBlockTag::Latest))
         .await
-        .context("get block")?
+        .context("failed to get block")?
     {
         MaybePendingBlockWithTxHashes::Block(l2_latest_block) => {
             let blocks_behind =

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -207,7 +207,7 @@ impl BeerusClient {
                     Err(e) => error!("sync error: {e}"),
                 };
                 debug!("state loop: delay {poll_interval:?}");
-                thread::sleep(poll_interval);
+                tokio::time::sleep(poll_interval).await;
             }
         };
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -30,11 +30,11 @@ pub const MAINNET_CC_ADDRESS: &str = "c662c410C0ECf747543f5bA90660f6ABeBD9C8c4";
 pub const MAINNET_CONSENSUS_RPC: &str = "https://www.lightclientdata.org";
 pub const MAINNET_FALLBACK_RPC: &str = "https://sync-mainnet.beaconcha.in";
 
-// testnet constants
-pub const TESTNET_CC_ADDRESS: &str = "de29d060D45901Fb19ED6C6e959EB22d8626708e";
-pub const TESTNET_CONSENSUS_RPC: &str =
-    "http://testing.prater.beacon-api.nimbus.team";
-pub const TESTNET_FALLBACK_RPC: &str = "https://sync-goerli.beaconcha.in";
+// sepolia testnet constants
+pub const SEPOLIA_CC_ADDRESS: &str = "E2Bb56ee936fd6433DC0F6e7e3b8365C906AA057";
+pub const SEPOLIA_CONSENSUS_RPC: &str =
+    "http://unstable.sepolia.beacon-api.nimbus.team";
+pub const SEPOLIA_FALLBACK_RPC: &str = "https://sync-sepolia.beaconcha.in";
 
 /// global config
 #[derive(Clone, Deserialize, Debug)]
@@ -122,7 +122,7 @@ impl Config {
     pub fn get_core_contract_address(&self) -> Result<Address> {
         match self.network {
             Network::MAINNET => Ok(Address::from_str(MAINNET_CC_ADDRESS)?),
-            Network::GOERLI => Ok(Address::from_str(TESTNET_CC_ADDRESS)?),
+            Network::SEPOLIA => Ok(Address::from_str(SEPOLIA_CC_ADDRESS)?),
             network => eyre::bail!("unsupported network: {network:?}"),
         }
     }
@@ -130,7 +130,7 @@ impl Config {
     pub fn get_consensus_rpc(&self) -> Result<String> {
         match self.network {
             Network::MAINNET => Ok(MAINNET_CONSENSUS_RPC.to_owned()),
-            Network::GOERLI => Ok(TESTNET_CONSENSUS_RPC.to_owned()),
+            Network::SEPOLIA => Ok(SEPOLIA_CONSENSUS_RPC.to_owned()),
             network => eyre::bail!("unsupported network: {network:?}"),
         }
     }
@@ -138,7 +138,7 @@ impl Config {
     pub fn get_fallback_address(&self) -> Result<String> {
         match self.network {
             Network::MAINNET => Ok(MAINNET_FALLBACK_RPC.to_owned()),
-            Network::GOERLI => Ok(TESTNET_FALLBACK_RPC.to_owned()),
+            Network::SEPOLIA => Ok(SEPOLIA_FALLBACK_RPC.to_owned()),
             network => eyre::bail!("unsupported network: {network:?}"),
         }
     }
@@ -152,9 +152,9 @@ impl Config {
                     cf.fetch_latest_checkpoint(&Network::MAINNET).await?;
                 Ok(format!("{checkpoint:x}"))
             }
-            Network::GOERLI => {
+            Network::SEPOLIA => {
                 let checkpoint =
-                    cf.fetch_latest_checkpoint(&Network::GOERLI).await?;
+                    cf.fetch_latest_checkpoint(&Network::SEPOLIA).await?;
                 Ok(format!("{checkpoint:x}"))
             }
             network => Err(eyre!("unsupported network: {network:?}")),


### PR DESCRIPTION
This PR adds Sepolia testnet configuration instead of Goerli one.

Respective Seploia support is necessary from helios part as well:
https://github.com/a16z/helios/pull/326