### PR TITLE
chore: Drop the `UnexpectedSpecVersion` error variant

### DIFF
--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -1,7 +1,6 @@
 use beerus_core::CoreError;
 use eyre::Report;
 use jsonrpsee::core::Error;
-use jsonrpsee::types::error::ErrorCode;
 use jsonrpsee::types::ErrorObjectOwned;
 use starknet::core::types::StarknetError;
 use starknet::providers::ProviderError;
@@ -14,8 +13,6 @@ pub enum BeerusRpcError {
     Provider(ProviderError),
     #[error("{0:?}")]
     Other((i32, String)),
-    #[error("unexpected RPC spec version: {0}")]
-    UnexpectedSpecVersion(String),
 }
 
 impl From<BeerusRpcError> for ErrorObjectOwned {
@@ -198,13 +195,6 @@ impl From<BeerusRpcError> for ErrorObjectOwned {
             },
             BeerusRpcError::Other(other_err) => {
                 ErrorObjectOwned::owned(other_err.0, other_err.1, None::<()>)
-            }
-            BeerusRpcError::UnexpectedSpecVersion(err) => {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    err,
-                    None::<()>,
-                )
             }
         }
     }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -6,6 +6,7 @@ use std::net::SocketAddr;
 use api::{BeerusRpcServer, SPEC_VERION};
 use beerus_core::client::BeerusClient;
 use error::BeerusRpcError;
+use eyre::eyre;
 use jsonrpsee::server::{ServerBuilder, ServerHandle};
 use starknet::providers::Provider;
 
@@ -18,15 +19,14 @@ impl BeerusRpc {
         Self { beerus }
     }
 
-    pub async fn run(
-        self,
-    ) -> Result<(SocketAddr, ServerHandle), BeerusRpcError> {
+    pub async fn run(self) -> eyre::Result<(SocketAddr, ServerHandle)> {
         let remote_spec_version =
             self.beerus.starknet_client.spec_version().await?;
 
         if remote_spec_version != SPEC_VERION {
-            return Err(BeerusRpcError::UnexpectedSpecVersion(
-                remote_spec_version,
+            return Err(eyre!(
+                "unexpected RPC spec version: {0}",
+                remote_spec_version
             ));
         }
 


### PR DESCRIPTION
This error variant is only used on startup, it doesn't bring any value to have it exposed through the RPC interface.