### PR TITLE
feat: use stateless execution in the rpc api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "beerus-experimental-api"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -593,6 +593,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "ureq",
 ]
 
 [[package]]
@@ -5430,8 +5431,22 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring 0.17.7",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring 0.17.7",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.3",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5456,12 +5471,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.7",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
+dependencies = [
+ "ring 0.17.7",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -7038,6 +7070,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
+dependencies = [
+ "base64 0.21.7",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.3",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.1",
+]
+
+[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7219,6 +7270,15 @@ name = "webpki-roots"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "which"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -730,8 +731,8 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.5.0-rc.2"
-source = "git+https://github.com/starkware-libs/blockifier?tag=v0.5.0-rc.2#a03f6a8251893b456f8eea94cca610bdd9618954"
+version = "0.5.0"
+source = "git+https://github.com/starkware-libs/blockifier?tag=v0.5.0#1f49dce7d026509d98546e71c0dfaf0a79d604e5"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -950,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0946e77ad3088c0e3b46f685ed0cf59810138abc285b112bd2386d9dba51cd"
+checksum = "10d9c31baeb6b52586b5adc88f01e90f86389d63d94363c562de5c79352e545b"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -964,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e6b8cf598402a9fb70a84ec599e16c66ba6f28930ac34edfdf00251b4f54db"
+checksum = "7148cb2d72a3db24a6d2ef2b2602102cc5099cb9f6b913e5047fb009cb3a22a1"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -987,18 +988,18 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2f336e086ea0c55a2d8db410b358a881e2910bd6cadd79059ee66666334a61"
+checksum = "5a761eb8e31ea65a2dd45f729c74f1770315f97124dad93d1f6853a10d460c6b"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47344ed1dd561da66d415b0d9c20f83c900d9956b86e36dc52abfed7f1ea2dc2"
+checksum = "f6d60bc5d72fe7a95ba34e041dcbdf1cf3bfccb87008a515514b74913fa8ff05"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -1013,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a43cb751b873725f7b9b4eee0161673b082f698d2436ee5ecda93b271219690"
+checksum = "356089e1b0a0ba9e115566191745613b3806a20259ad76764df82ab534d5412a"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -1025,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c5a172ef9a6c193dc03142148c3c2047a7f44175b9faaa75a0945261b1d7c"
+checksum = "fc43246cc2e5afd5a028bcdd63876ac3f8b1f4fb3ff785daaa0f0fbb51c9d906"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -1035,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feaf3b3beedb8ce3cabdb8a7777431d04b507bc264add66e18dd4ecc66e1d67b"
+checksum = "6bcb9a4a40e53fa099774bd08bbcc3430f51213cc7fb1b50c2e9d01155731798"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -1049,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb288727186146a68871d70d8c1f8de34db21195ff432fb5d90c9363adb038c"
+checksum = "1ba60e1e2477aa0f610ccf29189097d580464607c94b51741e1c18e64d6cee5f"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1074,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9613127cee21b8c45f0e42016b22a5bca08721ed3750d342d25662cfa9acd16a"
+checksum = "7f16ba1535e0cc5e79c2eff6592859bbdac03dc53d4dcdd26dbdbc04a77c3f5c"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -1094,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e231acf33b6c8c2ec0e491f42d9fa60f5b8d68f69ad87ed783970eeb59b16818"
+checksum = "81c8cf6e0ee3d6b19429cc1663738b22f1ecea7d51bf7452e8e1086f08798baf"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -1113,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d11dd056948249102687d1152ef1fec418c562128a74e0ee77c627446424bc"
+checksum = "67f9da66325ce7ed6c002360f26106fe79deb9f8a2fca30abdbb8d388da7bb46"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -1124,9 +1125,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d557c942c12cc372c46319a83c253bc2fbe14282f122e4577b77022c8faf97"
+checksum = "e198af1ab3d05c7fb8b6a9a7a2e9bce245a6c855df5f770b751d29874a23b152"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -1138,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18585650b961dada1311844d1a279f3fa9fce14445057210d99000672b09edb6"
+checksum = "0bf211f5431e2a6f4802b1b6483bf8e998e506a3be5369ed54a8807aae6e4dbf"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
@@ -1169,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4805057e20661751822c30ec57f2082e9a6a4b8f4c743d3142ae7e557e34fbdd"
+checksum = "6d7df81521c2125e3e95b683cc99374db1aebd7ddb317c5ca3dd92a235a9eb13"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1194,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ef37c891ea0ab18d818fd74ceea6a865685c93a1c7a4ace1301909ba87bb82"
+checksum = "07da3ca1434c62a7cc7cd77d2941ef47a1c23b37325781b59407b78d8c61d863"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -1220,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c830940809184a4cf74b70b8ca3e479272fbc91c9b7fbd0e1ab00c49a6f4f809"
+checksum = "122c9055eb609a511178e3dce577de061819fd4c4c6b7452804557f76ca43bbf"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -1235,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b99b1095e496a5060607c2aac7c0487843a38166b4882efb98244d588e9fbb1"
+checksum = "cf049d9aea65c6e38da219a3700c72f78795d11449d9adcec28047ef8d63bd23"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -1250,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab0d0990afbdad473e45a55979e8ca959f6e20a98455c52e57a2817b587c084"
+checksum = "3e1d75e0830279ca1bd0189e3326720d6e081225f7d81ed060bbd22c6b37e980"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1265,7 +1266,7 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "itertools 0.11.0",
- "num-bigint",
+ "num-traits 0.2.17",
  "once_cell",
  "salsa",
  "smol_str",
@@ -1273,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cef15ac7c317f2d3d494a594f2d35465e182400656e5a9cbb7d0cffc0fd227"
+checksum = "6a3c3be88c8562fbf93b0803c186e7282f6daad93576c07f61b04a591fde468f"
 dependencies = [
  "assert_matches",
  "cairo-felt",
@@ -1294,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3407dee40282408638acb476f4f8a4821fbd8c68eb6d1194a213a7de28e375a"
+checksum = "a38da6f98c6b16945c89d2ae351c82d636ed38d3e6eb02f7c8679e3e03a63988"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -1304,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04b3700cb2bc4d44f9e6b0e81de38501cd601db95ffe97469a06a80ea91b798"
+checksum = "2c9ffa8b3b8c47138c36b1907cebb5047dfc4de29ec10ece5bd6d6853243ec50"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -1335,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19152cb8a07c399d72e11bde4bc0c6b10db5c716e621b498b89573a00c517d0c"
+checksum = "47c64ae2bb00173e3a88760128bf72de356fa80eb19fa47602479063648b4003"
 dependencies = [
  "cairo-felt",
  "cairo-lang-casm",
@@ -1360,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1293b76a4f6711178dafd5a65b35de5289ef7737f1d4fb9c2cd5f25a36da2d1f"
+checksum = "8262c426a57e1e5ec297db24278464841500613445e2cb1c43d5f71ad91ee8d6"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -1376,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6211d20dc94543416f96b55c785273ab92180a58602121194ab5cb8282d1744"
+checksum = "70e2d692eae4bb4179a4a1148fd5eb738a91653d86750c813658ffad4a99fa97"
 dependencies = [
  "genco",
  "xshell",
@@ -1386,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.6.0-rc.1"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4ce2f99f15869184146f8223b2d09b0d93679cb2bea5465c96b981cecb40b6"
+checksum = "bf733a7cdc4166d0baf0ed8a98d9ada827daee6653b37d9326e334e53481c6d3"
 dependencies = [
  "hashbrown 0.14.3",
  "indexmap 2.1.0",
@@ -6253,9 +6254,9 @@ dependencies = [
 
 [[package]]
 name = "starknet_api"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8bfc63e01213a3a39af29aa061435b80a24919ac02d1dce758d9e1ac8be2a44"
+checksum = "9e6aeb260177f5ca6dde788e844825d8d83782905dbac1b24c0c620743284475"
 dependencies = [
  "cairo-lang-starknet-classes",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,7 @@ dependencies = [
  "axum",
  "base64 0.22.0",
  "blockifier",
+ "cairo-lang-starknet-classes",
  "cairo-vm",
  "flate2",
  "hex",

--- a/crates/experimental-api/Cargo.toml
+++ b/crates/experimental-api/Cargo.toml
@@ -25,6 +25,7 @@ hex = "0.4.3"
 
 base64 = "0.22.0"
 flate2 = "1.0.28"
+cairo-lang-starknet-classes = "2.6.3"
 
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/crates/experimental-api/Cargo.toml
+++ b/crates/experimental-api/Cargo.toml
@@ -2,7 +2,7 @@
 description = "JSON-RPC server & client auto-generated from the OpenRPC specification"
 edition = "2021"
 name = "beerus-experimental-api"
-version = "0.3.0"
+version = "0.1.0"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -26,6 +26,7 @@ hex = "0.4.3"
 base64 = "0.22.0"
 flate2 = "1.0.28"
 cairo-lang-starknet-classes = "2.6.3"
+ureq = { version = "2.9.6", features = ["json"] }
 
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/crates/experimental-api/Cargo.toml
+++ b/crates/experimental-api/Cargo.toml
@@ -18,10 +18,13 @@ tracing.workspace = true
 thiserror.workspace = true
 
 starknet-crypto = "0.6.1"
-blockifier = { git = "https://github.com/starkware-libs/blockifier", tag = "v0.5.0-rc.2" }
-starknet_api = "0.8.0"
+blockifier = { git = "https://github.com/starkware-libs/blockifier", tag = "v0.5.0" }
+starknet_api = "0.10.0"
 cairo-vm = "0.9.2"
 hex = "0.4.3"
 
 base64 = "0.22.0"
 flate2 = "1.0.28"
+
+[dev-dependencies]
+tracing-subscriber.workspace = true

--- a/crates/experimental-api/README.md
+++ b/crates/experimental-api/README.md
@@ -39,7 +39,7 @@ USAGE:
 cd /path/to/beerus
 
 cd ..
-git clone https://github.com/sergey-melnychuk/iamgroot.git --branch v0.2.6
+git clone https://github.com/sergey-melnychuk/iamgroot.git --branch v0.2.7
 cd iamgroot && cargo build --release
 cp ./target/release/iamgroot ../beerus/tmp
 cd ../beerus

--- a/crates/experimental-api/src/exe/err.rs
+++ b/crates/experimental-api/src/exe/err.rs
@@ -46,10 +46,7 @@ impl From<Error> for iamgroot::jsonrpc::Error {
     fn from(error: Error) -> Self {
         match error {
             Error::IamGroot(e) => e,
-            e => iamgroot::jsonrpc::Error {
-                code: 500,
-                message: e.to_string(),
-            }    
+            e => iamgroot::jsonrpc::Error { code: 500, message: e.to_string() },
         }
     }
 }

--- a/crates/experimental-api/src/exe/err.rs
+++ b/crates/experimental-api/src/exe/err.rs
@@ -1,3 +1,4 @@
+use cairo_lang_starknet_classes::casm_contract_class::StarknetSierraCompilationError;
 use thiserror::Error as ThisError;
 
 #[derive(Debug, ThisError)]
@@ -24,6 +25,8 @@ pub enum Error {
     ),
     #[error("Program error: {0:?}")]
     Program(#[from] cairo_vm::types::errors::program_errors::ProgramError),
+    #[error("Sierra compilation error: {0:?}")]
+    SierraCompilation(#[from] StarknetSierraCompilationError),
     #[error("{0}")]
     Custom(&'static str),
 }

--- a/crates/experimental-api/src/exe/err.rs
+++ b/crates/experimental-api/src/exe/err.rs
@@ -41,3 +41,15 @@ impl From<Error> for blockifier::state::errors::StateError {
         ))
     }
 }
+
+impl From<Error> for iamgroot::jsonrpc::Error {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::IamGroot(e) => e,
+            e => iamgroot::jsonrpc::Error {
+                code: 500,
+                message: e.to_string(),
+            }    
+        }
+    }
+}

--- a/crates/experimental-api/src/exe/mod.rs
+++ b/crates/experimental-api/src/exe/mod.rs
@@ -42,12 +42,12 @@ pub mod map;
 
 use err::Error;
 
-pub fn exec(
+pub fn call(
     client: &gen::client::blocking::Client,
-    call: gen::FunctionCall,
+    function_call: gen::FunctionCall,
 ) -> Result<CallInfo, Error> {
     let gen::FunctionCall { calldata, contract_address, entry_point_selector } =
-        call;
+        function_call;
 
     let calldata: Result<Vec<StarkFelt>, _> =
         calldata.into_iter().map(|felt| felt.try_into()).collect();
@@ -135,6 +135,7 @@ pub fn exec(
     let call_info =
         call_entry_point.execute(&mut proxy, &mut resources, &mut context)?;
 
+    tracing::debug!(?call_info, "call completed");
     Ok(call_info)
 }
 

--- a/crates/experimental-api/src/gen.rs
+++ b/crates/experimental-api/src/gen.rs
@@ -1,7 +1,7 @@
 pub use gen::*;
 
-#[allow(clippy::module_inception)]
 // vvv GENERATED CODE BELOW vvv
+#[allow(clippy::module_inception)]
 #[allow(non_snake_case)]
 #[allow(clippy::enum_variant_names)]
 pub mod gen {
@@ -5284,6 +5284,7 @@ pub mod gen {
     pub mod client {
         use super::*;
 
+        #[derive(Clone)]
         pub struct Client {
             client: reqwest::Client,
             url: String,
@@ -7456,22 +7457,12 @@ pub mod gen {
 
             #[derive(Clone)]
             pub struct Client {
-                client: reqwest::blocking::Client,
                 url: String,
             }
 
             impl Client {
                 pub fn new(url: &str) -> Self {
-                    Self {
-                        url: url.to_string(),
-                        client: reqwest::blocking::Client::new(),
-                    }
-                }
-                pub fn with_client(
-                    url: &str,
-                    client: reqwest::blocking::Client,
-                ) -> Self {
-                    Self { url: url.to_string(), client }
+                    Self { url: url.to_string() }
                 }
             }
 
@@ -7500,18 +7491,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -7569,18 +7557,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -7628,18 +7613,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -7699,18 +7681,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -7770,18 +7749,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -7841,18 +7817,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -7900,18 +7873,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -7959,18 +7929,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -8029,18 +7996,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -8088,18 +8052,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -8159,18 +8120,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -8229,18 +8187,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -8300,18 +8255,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -8371,18 +8323,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -8440,18 +8389,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -8510,18 +8456,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -8580,18 +8523,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -8649,18 +8589,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -8718,18 +8655,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -8787,18 +8721,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -8856,18 +8787,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -8926,18 +8854,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -8998,18 +8923,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -9069,18 +8991,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -9140,18 +9059,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -9211,18 +9127,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -9284,18 +9197,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -9343,18 +9253,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -9402,18 +9309,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -9473,18 +9377,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,
@@ -9542,18 +9443,15 @@ pub mod gen {
 
                     tracing::debug!(request=?req, "processing");
 
-                    let mut res: jsonrpc::Response = self
-                        .client
-                        .post(&self.url)
-                        .json(&req)
-                        .send()
+                    let mut res: jsonrpc::Response = ureq::post(&self.url)
+                        .send_json(&req)
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 4002,
                                 format!("Request failed: {e}."),
                             )
                         })?
-                        .json()
+                        .into_json()
                         .map_err(|e| {
                             jsonrpc::Error::new(
                                 5001,

--- a/crates/experimental-api/src/rpc.rs
+++ b/crates/experimental-api/src/rpc.rs
@@ -185,7 +185,7 @@ impl gen::Rpc for Context {
         .map_err(|e| {
             iamgroot::jsonrpc::Error::new(
                 500,
-                format!("join error: {}", e.to_string()),
+                format!("join error: {e}"),
             )
         })??;
 

--- a/crates/experimental-api/src/rpc.rs
+++ b/crates/experimental-api/src/rpc.rs
@@ -175,7 +175,6 @@ impl gen::Rpc for Context {
         request: FunctionCall,
         _block_id: BlockId,
     ) -> std::result::Result<Vec<Felt>, jsonrpc::Error> {
-
         let client = gen::client::blocking::Client::new(&self.url);
 
         let call_info = tokio::task::spawn_blocking(move || {
@@ -183,13 +182,13 @@ impl gen::Rpc for Context {
         })
         .await
         .map_err(|e| {
-            iamgroot::jsonrpc::Error::new(
-                500,
-                format!("join error: {e}"),
-            )
+            iamgroot::jsonrpc::Error::new(500, format!("join error: {e}"))
         })??;
 
-        let ret: Result<Vec<Felt>, Error> = call_info.execution.retdata.0
+        let ret: Result<Vec<Felt>, Error> = call_info
+            .execution
+            .retdata
+            .0
             .into_iter()
             .map(|e| e.try_into())
             .collect();

--- a/crates/experimental-api/tests/common/mod.rs
+++ b/crates/experimental-api/tests/common/mod.rs
@@ -10,6 +10,8 @@ pub enum Error {
     Exe(#[from] beerus_experimental_api::exe::err::Error),
     #[error("serde failed: {0:?}")]
     Json(#[from] serde_json::Error),
+    #[error("starknet api error: {0:?}")]
+    Api(#[from] starknet_api::StarknetApiError),
 }
 
 impl From<iamgroot::jsonrpc::Error> for Error {

--- a/crates/experimental-api/tests/exe.rs
+++ b/crates/experimental-api/tests/exe.rs
@@ -6,7 +6,7 @@ use beerus_experimental_api::{
 mod common;
 
 #[test]
-fn test_exec() -> Result<(), common::Error> {
+fn test_call() -> Result<(), common::Error> {
     let Ok(url) = std::env::var("BEERUS_EXPERIMENTAL_TEST_STARKNET_URL") else {
         return Ok(());
     };

--- a/crates/experimental-api/tests/exe.rs
+++ b/crates/experimental-api/tests/exe.rs
@@ -1,5 +1,5 @@
 use beerus_experimental_api::{
-    exe::exec,
+    exe::call,
     gen::{client::blocking::Client, FunctionCall},
 };
 
@@ -11,6 +11,11 @@ fn test_exec() -> Result<(), common::Error> {
         return Ok(());
     };
     let client = Client::new(&url);
+
+    // TODO: drop the logging
+    // cargo add -p beerus-experimental-api tracing-subscriber --dev
+    // RUST_LOG=beerus_experimental_api=debug cargo test --package beerus-experimental-api --test exe -- test_exec --exact --nocapture
+    tracing_subscriber::fmt::init();
 
     // TX: 0xcbb2b87d5378e682d650e0e7d36679b4557ba2bfa9d4e285b7168c04376b21
     let json = serde_json::json!({
@@ -31,9 +36,9 @@ fn test_exec() -> Result<(), common::Error> {
       "contract_address": "0x13e3ca9a377084c37dc7eacbd1d9f8c3e3733935bcbad887c32a0e213cd6fe0",
       "entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775"
     });
-    let call: FunctionCall = serde_json::from_value(json)?;
+    let function_call: FunctionCall = serde_json::from_value(json)?;
 
-    let call_info = exec(&client, call)?;
+    let call_info = call(&client, function_call)?;
     assert!(call_info.execution.retdata.0.is_empty());
 
     Ok(())

--- a/crates/experimental-api/tests/rpc.rs
+++ b/crates/experimental-api/tests/rpc.rs
@@ -78,6 +78,9 @@ async fn test_blockNumber() -> Result<(), common::Error> {
 }
 
 #[tokio::test]
+#[ignore = "TODO"]
+// thread 'test_call' panicked at /home/work/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.36.0/src/runtime/blocking/shutdown.rs:51:21:
+// Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.
 #[allow(non_snake_case)]
 async fn test_call() -> Result<(), common::Error> {
     let Some(ctx) = ctx().await else {

--- a/crates/experimental-api/tests/rpc.rs
+++ b/crates/experimental-api/tests/rpc.rs
@@ -78,9 +78,6 @@ async fn test_blockNumber() -> Result<(), common::Error> {
 }
 
 #[tokio::test]
-#[ignore = "TODO"]
-// thread 'test_call' panicked at /home/work/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.36.0/src/runtime/blocking/shutdown.rs:51:21:
-// Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.
 #[allow(non_snake_case)]
 async fn test_call() -> Result<(), common::Error> {
     let Some(ctx) = ctx().await else {


### PR DESCRIPTION
This PR completes stateless execution implementation (with necessary dependency upgrades) and exposes it through the RPC API (existing unit-test coverage is satisfied).