### PR TITLE
chore: make beerus binary run as default

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -3,6 +3,7 @@ description = "CLI for the Beerus Light Client"
 edition = "2021"
 name = "beerus-cli"
 version = "0.4.0"
+default-run = "beerus"
 
 [dependencies]
 tokio = { workspace = true }


### PR DESCRIPTION
Currently, we have two available binaries: `beerus` and `beerus-experimental`.

This PR makes `beerus` as a [default binary for the run](https://doc.rust-lang.org/cargo/reference/manifest.html#the-default-run-field) command.
Without this change, the instruction from our README for running code will fail:

```bash
cargo run --release -- -c ./path/to/config.toml

error: `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
available binaries: beerus, beerus-experimental
```

I think it makes more sense to have `beerus` as a default binary rather than specifying binary using `--bin` every time we want to run a client.

