### PR TITLE
Add RPC provider section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,21 @@
 
 ## Getting Started
 
+### Running Beerus for the first time
+
+Copy the configuration file from `etc/conf/beerus.toml` and set up the RPC provider URLs in the copy.
+Make sure that providers are compatible. Read more about providers [here](#rpc-providers)
+
+Then run:
+```bash
+cargo run --release -- -c ./path/to/config.toml
+```
+
+Once Beerus has started to verify that everything is working correctly, run this command:
+```
+hurl etc/rpc/starknet_getStateRoot.hurl
+```
 ### Configuration
-
-Beerus relies on TWO untrusted RPC endpoints, one for L1 (Ethereum), and one for L2 (Starknet). 
-As these are untrusted they will typically not be nodes run on your local host or your local network.
-
-Beerus requires the [v0.6.0 of the Starknet OpenRPC specs](https://github.com/starkware-libs/starknet-specs/tree/v0.6.0).
-
-These untrusted RPC providers must adhere to both the L1 `eth_getProof` endpoint
-as well as the L2 `pathfinder_getProof` endpoint ([detailed instructions needed!](https://github.com/eigerco/beerus/issues/602)).For this we recommend using
-[Alchemy](https://docs.alchemy.com/reference/starknet-api-faq#what-versions-of-starknet-api-are-supported) as your untrusted L2 node provider. 
-
-More API providers can be found [here](https://docs.starknet.io/documentation/tools/api-services/).
-
-*NOTE: we rely on [helios](https://github.com/a16z/helios) for both valid checkpoint values and consensus rpc urls*
 
 | field   | example | description |
 | ----------- | ----------- | ----------- |
@@ -59,17 +60,64 @@ eth_execution_rpc = "https://eth-sepolia.g.alchemy.com/v2/{YOUR_API_KEY}"
 starknet_rpc = "https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0.6/{YOUR_API_KEY}"
 ```
 
-### Running Beerus for the first time
+#### RPC providers
+Beerus relies on TWO untrusted RPC endpoints, one for L1 (Ethereum), and one for L2 (Starknet).
+As these are untrusted they will typically not be nodes run on your local host or your local network.
 
-Copy the configuration file from `etc/conf/beerus.toml` and set up the API provider URLs in the copy.
+##### Starknet RPC endpoint
+Beerus requires the [v0.6.0 of the Starknet OpenRPC specs](https://github.com/starkware-libs/starknet-specs/tree/v0.6.0).
 
-Then run:
+Starknet RPC provider must also support the [Pathfinder's extension API](https://github.com/eqlabs/pathfinder#pathfinder-extension-api) `pathfinder_getProof` endpoint. 
+
+You can check if the provider is compatible by running this command:
 ```bash
-cargo run --release -- -c ./path/to/config.toml
-
-# Once Beerus has started, 
-hurl etc/rpc/starknet_getStateRoot.hurl
+# This is an example RPC url. Use your RPC provider url to check if the node is compatible.
+STARKNET_RPC_URL="https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0.6/{YOUR_API_KEY}"
+curl --request POST \
+     --url $STARKNET_RPC_URL \
+     --header 'content-type: application/json' \
+     --data '
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "pathfinder_getProof",
+  "params": [
+    {
+      "block_number": 56072
+    },
+    "0x07cb0dca5767f238b056665d2f8350e83a2dee7eac8ec65e66bbc790a4fece8a",
+    [
+        "0x01d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+    ]
+  ]
+}
+'
 ```
+
+If you get a response similar to the one below, then the provider is **not compatible**.
+```
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32601,
+    "message": "method 'pathfinder_getProof' not found"
+  }
+}
+```
+
+We recommend using one of these providers:
+- [Alchemy](https://docs.alchemy.com/reference/starknet-api-faq#what-versions-of-starknet-api-are-supported)
+- [Chainstack](https://docs.chainstack.com/docs/starknet-tooling)
+- [Reddio](https://docs.reddio.com/guide/node/starknet.html#grab-starknet-sepolia-endpoint)
+
+
+More API providers can be found [here](https://docs.starknet.io/documentation/tools/api-services/).
+
+##### Ethereum RPC endpoint
+For the Ethereum RPC provider, there are no special requirements. The provider must support [Ethereum JSON-RPC Specification](https://ethereum.github.io/execution-apis/api-documentation/)
+
+*NOTE: we rely on [helios](https://github.com/a16z/helios) for both valid checkpoint values and consensus rpc urls*
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -39,12 +39,25 @@ More API providers can be found [here](https://docs.starknet.io/documentation/to
 | field   | example | description |
 | ----------- | ----------- | ----------- |
 | network | MAINNET or SEPOLIA| network to query |
-| eth_execution_rpc | https://eth-mainnet.g.alchemy.com/v2/YOURAPIKEY | untrusted l1 node provider url |
-| starknet_rpc | https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.6/YOURAPIKEY | untrusted l2 node provider url |
+| eth_execution_rpc | https://eth-mainnet.g.alchemy.com/v2/{YOUR_API_KEY}| untrusted l1 node provider url |
+| starknet_rpc | https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.6/{YOUR_API_KEY}| untrusted l2 node provider url |
 | data_dir | tmp | `OPTIONAL` location to store both l1 and l2 data |
 | poll_secs | 5 | `OPTIONAL` seconds to wait for querying sn state |
 | rpc_addr | 127.0.0.1:3030 | `OPTIONAL` local address to listen for rpc reqs |
 | fee_token_addr | 0x049d36...e004dc7 | `OPTIONAL` fee token to check for `getBalance` |
+
+When you select a network, check that `eth_execution_rpc` and `starknet_rpc` urls also point to their corresponding networks. For example:
+
+MAINNET
+```
+eth_execution_rpc = "https://eth-mainnet.g.alchemy.com/v2/{YOUR_API_KEY}"
+starknet_rpc = "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.6/{YOUR_API_KEY}"
+```
+SEPOLIA
+```
+eth_execution_rpc = "https://eth-sepolia.g.alchemy.com/v2/{YOUR_API_KEY}"
+starknet_rpc = "https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0.6/{YOUR_API_KEY}"
+```
 
 ### Running Beerus for the first time
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ More API providers can be found [here](https://docs.starknet.io/documentation/to
 
 | field   | example | description |
 | ----------- | ----------- | ----------- |
-| network | MAINNET or GOERLI | network to query |
+| network | MAINNET or SEPOLIA| network to query |
 | eth_execution_rpc | https://eth-mainnet.g.alchemy.com/v2/YOURAPIKEY | untrusted l1 node provider url |
 | starknet_rpc | https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.6/YOURAPIKEY | untrusted l2 node provider url |
 | data_dir | tmp | `OPTIONAL` location to store both l1 and l2 data |

--- a/etc/conf/.env.example
+++ b/etc/conf/.env.example
@@ -1,4 +1,4 @@
-# network, e.g. GOERLI
+# network, e.g. SEPOLIA
 NETWORK=MAINNET
 
 # Ethereum execution RPC URL


### PR DESCRIPTION
This PR adds a RPC providers section to the README, which fixes [#602](https://github.com/eigerco/beerus/issues/602). I also reorganized it slightly, so I hope it is more readable now.

Also, since we introduced the `SEPOLIA` network here: https://github.com/eigerco/beerus/pull/612  there were still a few places that mentioned the deprecated `GORELI` network. I replaced all of them.
