### PR TITLE
chore: remove `CoreError` as redundant

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,14 +2,3 @@ pub mod client;
 pub mod config;
 pub mod storage_proofs;
 pub mod utils;
-
-use eyre::Report;
-use thiserror::Error;
-
-#[derive(Debug, Error)]
-pub enum CoreError {
-    #[error("could not fetch l1 val: {0}")]
-    FetchL1Val(Report),
-    #[error("storage proof error: {0}")]
-    StorageProof(Report),
-}

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -1,4 +1,3 @@
-use beerus_core::CoreError;
 use eyre::Report;
 use jsonrpsee::core::Error as JsonRpcError;
 use jsonrpsee::types::ErrorObjectOwned;
@@ -215,14 +214,6 @@ impl From<RpcError> for ErrorObjectOwned {
     }
 }
 
-// TODO: break this unnecessary coupling
-impl From<CoreError> for RpcError {
-    fn from(err: CoreError) -> Self {
-        RpcError::Other((-32601, format!("{err}")))
-    }
-}
-
-// TODO: break this unnecessary coupling
 impl From<Report> for RpcError {
     fn from(err: Report) -> Self {
         RpcError::Other((-32601, format!("{err}")))


### PR DESCRIPTION
Plain wrappers over `eyre::Report` do not make much sense at all