### PR TITLE
chore(deps): bump `eyre` to 0.6.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,9 +2605,9 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6267a1fa6f59179ea4afc8e50fd8612a3cc60bc858f786ff877a4a8cb042799"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 ## Tokio WASM support: https://docs.rs/tokio/latest/tokio/#wasm-support
 tokio = { version = "1", features = ["sync", "macros", "io-util", "rt", "time"] }
-eyre = "0.6.8"
+eyre = "0.6.12"
 serde = "1.0.156"
 serde_with = "2.3.3"
 starknet = "0.9.0"


### PR DESCRIPTION
https://github.com/eigerco/beerus/security/dependabot/26