### PR TITLE
tests(rpc): clean up fixtures for integration tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           cache-on-failure: true
       - run: cargo install cargo-udeps --locked
-      - run: cargo +nightly udeps --all-targets
+      - run: cargo +nightly udeps --all-targets --all-features
 
   typos:
       runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all -- -D warnings
+      - run: cargo clippy --all --all-features --all-targets -- -D warnings
 
   lint:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,10 +601,8 @@ name = "beerus-rpc"
 version = "0.4.0"
 dependencies = [
  "beerus-core",
- "cached 0.49.3",
  "eyre",
  "jsonrpsee 0.20.3",
- "lazy_static",
  "pretty_assertions",
  "reqwest",
  "serde",
@@ -742,7 +740,7 @@ dependencies = [
  "ark-ff",
  "ark-secp256k1",
  "ark-secp256r1",
- "cached 0.44.0",
+ "cached",
  "cairo-felt",
  "cairo-lang-casm",
  "cairo-lang-runner",
@@ -883,7 +881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b195e4fbc4b6862bbd065b991a34750399c119797efff72492f28a5864de8700"
 dependencies = [
  "async-trait",
- "cached_proc_macro 0.17.0",
+ "cached_proc_macro",
  "cached_proc_macro_types",
  "futures",
  "hashbrown 0.13.2",
@@ -894,39 +892,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cached"
-version = "0.49.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8e463fceca5674287f32d252fb1d94083758b8709c160efae66d263e5f4eba"
-dependencies = [
- "ahash 0.8.7",
- "cached_proc_macro 0.20.0",
- "cached_proc_macro_types",
- "hashbrown 0.14.3",
- "instant",
- "once_cell",
- "thiserror",
-]
-
-[[package]]
 name = "cached_proc_macro"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48814962d2fd604c50d2b9433c2a41a0ab567779ee2c02f7fba6eca1221f082"
 dependencies = [
  "cached_proc_macro_types",
- "darling 0.14.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "cached_proc_macro"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9f16c0d84de31a2ab7fdf5f7783c14631f7075cf464eb3bb43119f61c9cb2a"
-dependencies = [
  "darling 0.14.4",
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,9 @@ version = "0.4.0"
 dependencies = [
  "beerus-core",
  "eyre",
+ "futures",
  "jsonrpsee 0.20.3",
+ "pin-utils",
  "pretty_assertions",
  "reqwest",
  "serde",

--- a/crates/core/examples/call.rs
+++ b/crates/core/examples/call.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
         calldata: vec![],
     };
 
-    let res = beerus.starknet_client.call(calldata, &block_id).await?;
+    let res = beerus.starknet_client.call(calldata, block_id).await?;
     println!("{:?}", res);
     Ok(())
 }

--- a/crates/experimental-api/tests/rpc.rs
+++ b/crates/experimental-api/tests/rpc.rs
@@ -125,14 +125,14 @@ async fn test_estimateFee() -> Result<(), common::Error> {
         "0x1",
     ];
     let calldata: Result<Vec<Felt>, _> =
-        calldata.into_iter().map(|felt| Felt::try_new(felt)).collect();
+        calldata.into_iter().map(Felt::try_new).collect();
 
     let signature = vec![
         "0x42527ffe9912b338983cbed67e139cfcc26a4d8cf1d1c2a85e4125fdf5f59ed",
         "0x636147d06fefd02ed37984b752556d4b9aefdac1a50b3df0528ec7c201ad84b",
     ];
     let signature: Result<Vec<Felt>, _> =
-        signature.into_iter().map(|felt| Felt::try_new(felt)).collect();
+        signature.into_iter().map(Felt::try_new).collect();
 
     let request = vec![
         BroadcastedTxn::BroadcastedInvokeTxn(
@@ -195,7 +195,7 @@ async fn test_getBlockWithTxHashes() -> Result<(), common::Error> {
     let GetBlockWithTxHashesResult::BlockWithTxHashes(ret) = ret else {
         panic!("unexpected pending block");
     };
-    assert!(ret.block_body_with_tx_hashes.transactions.len() > 0);
+    assert!(!ret.block_body_with_tx_hashes.transactions.is_empty());
     Ok(())
 }
 
@@ -213,7 +213,7 @@ async fn test_getBlockWithTxs() -> Result<(), common::Error> {
     let GetBlockWithTxsResult::BlockWithTxs(ret) = ret else {
         panic!("unexpected pending block");
     };
-    assert!(ret.block_body_with_txs.transactions.len() > 0);
+    assert!(!ret.block_body_with_txs.transactions.is_empty());
     Ok(())
 }
 

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -5,7 +5,7 @@ name = "beerus-rpc"
 version = "0.4.0"
 
 [features]
-integration-tests = ["cached", "lazy_static", "pretty_assertions", "reqwest", "serde_json", "tokio"]
+integration-tests = ["pretty_assertions", "reqwest", "serde_json", "tokio"]
 
 [dependencies]
 beerus-core = { path = "../core" }
@@ -18,8 +18,6 @@ thiserror.workspace = true
 tracing.workspace = true
 
 # Integration test dependencies
-cached = { version = "0.49.3", optional = true }
-lazy_static = { version = "1.4.0", optional = true }
 pretty_assertions = { version = "1.4.0", optional = true }
 reqwest = { version = "0.11.16", optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -22,3 +22,5 @@ pretty_assertions = { version = "1.4.0", optional = true }
 reqwest = { version = "0.11.16", optional = true }
 serde_json = { version = "1.0", optional = true }
 tokio = { workspace = true, optional = true }
+futures = "0.3.30"
+pin-utils = "0.1.0"

--- a/crates/rpc/tests/rpc.rs
+++ b/crates/rpc/tests/rpc.rs
@@ -102,6 +102,7 @@ mod blocks {
 mod fixtures {
     use super::*;
 
+    // TODO(#643): consider adding a cache here if necessary
     pub async fn latest_block(
     ) -> (JsonRpcClient<HttpTransport>, BlockWithTxs, BlockId) {
         let block = blocks::head().await.expect("failed to pull latest block");
@@ -109,6 +110,7 @@ mod fixtures {
         (rpc_client(), block, block_id)
     }
 
+    // TODO(#643): consider adding a cache here if necessary
     pub async fn block_with_min_ten_txs(
     ) -> (JsonRpcClient<HttpTransport>, BlockWithTxs, BlockId) {
         let block = blocks::find(|block| block.transactions.len() >= 10, 1000)

--- a/crates/rpc/tests/rpc.rs
+++ b/crates/rpc/tests/rpc.rs
@@ -11,9 +11,7 @@ use starknet::{
         MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
         MaybePendingTransactionReceipt, Transaction, TransactionReceipt,
     },
-    providers::{
-        jsonrpc::HttpTransport, JsonRpcClient, Provider,
-    },
+    providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider},
 };
 
 fn rpc_client() -> JsonRpcClient<HttpTransport> {
@@ -328,7 +326,7 @@ async fn test_get_transaction_by_block_id_and_index() {
         // `starknet-rs` doesn't implement `PartialEq` on its DTOs, and transactions have many *variants which makes pure Rust comparison painful.
         // Just serialize these to compare them.
         pretty_assertions::assert_eq!(
-            serde_json::to_value(&transaction).unwrap(),
+            serde_json::to_value(transaction).unwrap(),
             serde_json::to_value(&expected.transactions[transaction_index])
                 .unwrap(),
         )
@@ -357,8 +355,8 @@ async fn test_get_transaction_by_hash() {
         // `starknet-rs` doesn't implement `PartialEq` on its DTOs, and transactions have many *variants which makes pure Rust comparison painful.
         // Just serialize these to compare them.
         pretty_assertions::assert_eq!(
-            serde_json::to_value(&transaction).unwrap(),
-            serde_json::to_value(&expected).unwrap(),
+            serde_json::to_value(transaction).unwrap(),
+            serde_json::to_value(expected).unwrap(),
         )
     }
 

--- a/crates/rpc/tests/rpc.rs
+++ b/crates/rpc/tests/rpc.rs
@@ -33,7 +33,9 @@ mod blocks {
         latest: Option<u64>,
     }
 
-    async fn next(state: State) -> Option<(BlockWithTxs, State)> {
+    async fn change_stream_state(
+        state: State,
+    ) -> Option<(BlockWithTxs, State)> {
         let latest = if let Some(latest) = state.latest.as_ref() {
             *latest
         } else {
@@ -66,7 +68,7 @@ mod blocks {
 
     fn stream() -> impl Stream<Item = BlockWithTxs> {
         let state = State { client: rpc_client(), latest: None };
-        stream::unfold(state, next)
+        stream::unfold(state, change_stream_state)
     }
 
     pub async fn head() -> Option<BlockWithTxs> {


### PR DESCRIPTION
This PR removes dysfunctional caching in the integration test suite and changes the test fixtures to a stream-based (potentially more async-friendly) implementation.

Most comfortable way to review is commit-by-commit.