### PR TITLE
ci: Run the ITs against multiple API providers

### DIFF
--- a/.github/workflows/rust-integration-tests-alchemy.yml
+++ b/.github/workflows/rust-integration-tests-alchemy.yml
@@ -1,4 +1,4 @@
-name: rust-integration-tests
+name: rust-integration-tests-alchemy
 on:
   schedule:
     - cron: "0 8,20 * * *"
@@ -8,7 +8,7 @@ on:
 jobs:
   integration:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -19,11 +19,10 @@ jobs:
 
       - name: start beerus RPC on MAINNET
         env:
-          BEERUS_VERSION: "ci"
-          NETWORK: "mainnet"
           ETH_EXECUTION_RPC: ${{ secrets.ETH_EXECUTION_RPC_MAINNET }}
-          STARKNET_RPC: ${{ secrets.STARKNET_RPC_0_6_0_MAINNET }}
-        run: ./target/release/beerus & while ! timeout 1 bash -c "echo > /dev/tcp/localhost/3030" 2> /dev/null; do sleep 2; done
+          STARKNET_RPC: ${{ secrets.STARKNET_RPC_0_6_0_MAINNET_ALCHEMY }}
+        # Start Beerus, then try to reach the port every second for 60 seconds.
+        run: ./target/release/beerus & for i in {1..60}; do timeout 1 bash -c "echo > /dev/tcp/localhost/3030" 2> /dev/null && break || sleep 1; done
 
       - name: run integration test on MAINNET
         run: cargo test --package beerus-rpc --features integration-tests

--- a/.github/workflows/rust-integration-tests-chainstack.yml
+++ b/.github/workflows/rust-integration-tests-chainstack.yml
@@ -1,0 +1,31 @@
+name: rust-integration-tests-chainstack
+on:
+  schedule:
+    - cron: "0 8,20 * * *"
+  workflow_dispatch:
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: build beerus
+        run: cargo build -p beerus-cli --release
+
+      - name: start beerus RPC on MAINNET
+        env:
+          ETH_EXECUTION_RPC: ${{ secrets.ETH_EXECUTION_RPC_MAINNET }}
+          STARKNET_RPC: ${{ secrets.STARKNET_RPC_0_6_0_MAINNET_CHAINSTACK }}
+        # Start Beerus, then try to reach the port every second for 60 seconds.
+        run: ./target/release/beerus & for i in {1..60}; do timeout 1 bash -c "echo > /dev/tcp/localhost/3030" 2> /dev/null && break || sleep 1; done
+
+      - name: run integration test on MAINNET
+        run: cargo test --package beerus-rpc --features integration-tests
+
+      - name: stop RPC
+        run: kill $(lsof -t -i:3030)
+ 

--- a/.github/workflows/rust-integration-tests-reddio.yml
+++ b/.github/workflows/rust-integration-tests-reddio.yml
@@ -1,0 +1,31 @@
+name: rust-integration-tests-reddio
+on:
+  schedule:
+    - cron: "0 8,20 * * *"
+  workflow_dispatch:
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: build beerus
+        run: cargo build -p beerus-cli --release
+
+      - name: start beerus RPC on MAINNET
+        env:
+          ETH_EXECUTION_RPC: ${{ secrets.ETH_EXECUTION_RPC_MAINNET }}
+          STARKNET_RPC: ${{ secrets.STARKNET_RPC_0_6_0_MAINNET_REDDIO }}
+        # Start Beerus, then try to reach the port every second for 60 seconds.
+        run: ./target/release/beerus & for i in {1..60}; do timeout 1 bash -c "echo > /dev/tcp/localhost/3030" 2> /dev/null && break || sleep 1; done
+
+      - name: run integration test on MAINNET
+        run: cargo test --package beerus-rpc --features integration-tests
+
+      - name: stop RPC
+        run: kill $(lsof -t -i:3030)
+ 


### PR DESCRIPTION
Run the ITs against Alchemy, Reddio and Chainstack.

Keep Alchemy as the default check for a git push.
Have the other two run periodically.

Bound the health check loop to a max timeout of 60s.
Increase the job timeout to 30 minutes. 15 minutes leaves too little room for the unexpected.

Although these all rely on Pathfinder, this may still help determine if any of these is more reliable than the others, and will offer us redundancy in the case of an incident on Alchemy's side. It's good for CI, but also for Beerus users.

Secrets & variables will have to be updated before merging this PR.