### PR TITLE
feat: Extend support for env-based configuration

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -9,9 +9,9 @@ pub struct Args {
 }
 
 pub fn get_config(args: Args) -> eyre::Result<Config> {
-    Ok(if let Some(path) = args.config.as_ref() {
-        Config::from_file(path)?
+    if let Some(path) = args.config.as_ref() {
+        Config::from_file(path)
     } else {
         Config::from_env()
-    })
+    }
 }


### PR DESCRIPTION
BREAKING CHANGE: `Config::from_env` now returns an `eyre::Result` instead of panicking on site.

The primary motivation is #630 , but I also wanted more explicit messages when running Beerus without specifying the `STARKNET_RPC` and `ETH_EXECUTION_RPC` keys.