### PR TITLE
chore: Regroup the IT dependencies

### DIFF
--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -5,22 +5,22 @@ name = "beerus-rpc"
 version = "0.4.0"
 
 [features]
-integration-tests = ["pretty_assertions", "cached"]
+integration-tests = ["cached", "lazy_static", "pretty_assertions", "reqwest", "serde_json", "tokio"]
 
 [dependencies]
 beerus-core = { path = "../core" }
-cached = { version = "0.49.3", optional = true }
 starknet.workspace = true
 eyre.workspace = true
 jsonrpsee = { version = "0.20.3", features = ["macros", "server", "server-core"] }
-pretty_assertions = { version = "1.4.0", optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_with.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-[dev-dependencies]
-lazy_static = "1.4.0"
-serde_json = "1.0"
-reqwest = "0.11.13"
-tokio.workspace = true
+# Integration test dependencies
+cached = { version = "0.49.3", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
+pretty_assertions = { version = "1.4.0", optional = true }
+reqwest = { version = "0.11.16", optional = true }
+serde_json = { version = "1.0", optional = true }
+tokio = { workspace = true, optional = true }


### PR DESCRIPTION
Some of these were marked as `dev-dependencies` while others were marked as optional in the main `dependencies` section.
[Related change](https://github.com/eigerco/beerus/pull/597/files#diff-ffd0a067e8dfc242560e9c699ab2ceb3b68c164e739f8840e527a9aec0f5106f)

Because these tests are hidden behind the `integration-tests` feature, all of these dependencies are currently optional.
Because `dev-dependencies` can't be marked as optional, I found it simpler to just move these to a subsection of the `dependencies` section.