### PR TITLE
chore: Update the CI badge to the new workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="etc/beerus.png" height="250" />
   <div align="center">
 
-  [![CI Action Status](https://github.com/eigerco/beerus/actions/workflows/ci.yml/badge.svg)](https://github.com/eigerco/beerus/actions/workflows/ci.yml)
+  [![CI Action Status](https://github.com/eigerco/beerus/actions/workflows/rust-integration-tests-alchemy.yml/badge.svg)](https://github.com/eigerco/beerus/actions/workflows/rust-integration-tests-alchemy.yml)
   [![Check Workflow Status](https://github.com/eigerco/beerus/actions/workflows/check.yml/badge.svg)](https://github.com/eigerco/beerus/actions/workflows/check.yml)
   ![starknet-version-v0.13.0](https://img.shields.io/badge/Starknet_Version-v0.13.0-2ea44f?labelColor=282d33&logo=ethereum)
   [![jsonrpc-spec-v0.6.0](https://img.shields.io/badge/JSON--RPC-v0.6.0-2ea44f?labelColor=282d33&logo=ethereum)](https://github.com/starkware-libs/starknet-specs/tree/v0.6.0)


### PR DESCRIPTION
The CI badge is currently broken due to the recently renamed workflow files.
This change would make it point at the new alchemy workflow

Change preview:
<img width="761" alt="Screenshot 2024-04-24 at 16 25 49" src="https://github.com/eigerco/beerus/assets/15252136/49db51ca-8a88-4e8c-a142-0dfe91fa0bc3">