### PR TITLE
fix: Expose the experimental server to the same URL as Beerus

### DIFF
--- a/crates/experimental-api/src/rpc.rs
+++ b/crates/experimental-api/src/rpc.rs
@@ -56,7 +56,7 @@ fn serve_on(url: &str, listener: TcpListener) -> Result<Server, Error> {
         url: url.to_owned(),
     };
 
-    let app = Router::new().route("/rpc", post(handle_request)).with_state(ctx);
+    let app = Router::new().route("/", post(handle_request)).with_state(ctx);
 
     let (tx, rx) = oneshot::channel::<()>();
     let port = listener.local_addr()?.port();

--- a/crates/experimental-api/tests/rpc.rs
+++ b/crates/experimental-api/tests/rpc.rs
@@ -23,7 +23,7 @@ pub async fn ctx() -> Option<Context> {
     let server = serve(&url, "127.0.0.1:0").await.ok()?;
     tracing::info!(port = server.port(), "test server is up");
 
-    let url = format!("http://localhost:{}/rpc", server.port());
+    let url = format!("http://localhost:{}/", server.port());
     let client = Client::new(&url);
     Some(Context { server, client })
 }


### PR DESCRIPTION
The experimental server expose its JSON-RPC interface at the path `/rpc` while Beerus does that at the root path.

This PR makes the experimental server use the root path as well so both behaviors are consistent.