### PR TITLE
chore(tests): organise fixtures

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,5 @@
 name: check
 on:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,6 +27,7 @@ jobs:
   test-experimental:
     runs-on: ubuntu-latest
     env:
+      BEERUS_EXPERIMENTAL_TEST_RUN: 1
       BEERUS_EXPERIMENTAL_TEST_STARKNET_URL: ${{ secrets.STARKNET_RPC_0_6_0_MAINNET }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/hurl-integration-tests.yml
+++ b/.github/workflows/hurl-integration-tests.yml
@@ -1,8 +1,7 @@
 name: hurl-integration-tests
 on:
-  workflow_dispatch:
   schedule:
-    - cron: "0 8,20 * * *"
+    - cron: "0 8 * * *"
 
 jobs:
   integration:

--- a/.github/workflows/rust-integration-tests-alchemy.yml
+++ b/.github/workflows/rust-integration-tests-alchemy.yml
@@ -7,6 +7,8 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      - BEERUS_INTEGRATION_TEST_RUN: 0
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -23,7 +25,7 @@ jobs:
         run: ./target/release/beerus & ./scripts/wait-for-it.sh localhost:3030 -t 120
 
       - name: run integration test on MAINNET
-        run: cargo test --package beerus-rpc --features integration-tests
+        run: cargo test -p beerus-rpc
 
       - name: stop RPC
         run: kill $(lsof -t -i:3030)

--- a/.github/workflows/rust-integration-tests-alchemy.yml
+++ b/.github/workflows/rust-integration-tests-alchemy.yml
@@ -1,9 +1,7 @@
 name: rust-integration-tests-alchemy
 on:
   schedule:
-    - cron: "0 8,20 * * *"
-  push:
-  workflow_dispatch:
+    - cron: "0 8 * * *"
 
 jobs:
   integration:

--- a/.github/workflows/rust-integration-tests-chainstack.yml
+++ b/.github/workflows/rust-integration-tests-chainstack.yml
@@ -1,8 +1,7 @@
 name: rust-integration-tests-chainstack
 on:
   schedule:
-    - cron: "0 8,20 * * *"
-  workflow_dispatch:
+    - cron: "0 8 * * *"
 
 jobs:
   integration:

--- a/.github/workflows/rust-integration-tests-chainstack.yml
+++ b/.github/workflows/rust-integration-tests-chainstack.yml
@@ -7,6 +7,8 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      - BEERUS_INTEGRATION_TEST_RUN: 0
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -23,7 +25,7 @@ jobs:
         run: ./target/release/beerus & ./scripts/wait-for-it.sh localhost:3030 -t 120
 
       - name: run integration test on MAINNET
-        run: cargo test --package beerus-rpc --features integration-tests
+        run: cargo test -p beerus-rpc
 
       - name: stop RPC
         run: kill $(lsof -t -i:3030)

--- a/.github/workflows/rust-integration-tests-reddio.yml
+++ b/.github/workflows/rust-integration-tests-reddio.yml
@@ -1,8 +1,7 @@
 name: rust-integration-tests-reddio
 on:
   schedule:
-    - cron: "0 8,20 * * *"
-  workflow_dispatch:
+    - cron: "0 8 * * *"
 
 jobs:
   integration:

--- a/.github/workflows/rust-integration-tests-reddio.yml
+++ b/.github/workflows/rust-integration-tests-reddio.yml
@@ -7,6 +7,8 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      - BEERUS_INTEGRATION_TEST_RUN: 0
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -23,7 +25,7 @@ jobs:
         run: ./target/release/beerus & ./scripts/wait-for-it.sh localhost:3030 -t 120
 
       - name: run integration test on MAINNET
-        run: cargo test --package beerus-rpc --features integration-tests
+        run: cargo test -p beerus-rpc
 
       - name: stop RPC
         run: kill $(lsof -t -i:3030)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ checksum = "8037e03c7f462a063f28daec9fda285a9a89da003c552f8637a80b9c8fd96241"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -186,7 +186,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -371,7 +371,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -408,7 +408,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -663,7 +663,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.65",
+ "syn 2.0.66",
  "which",
 ]
 
@@ -1103,7 +1103,7 @@ checksum = "67f9da66325ce7ed6c002360f26106fe79deb9f8a2fca30abdbb8d388da7bb46"
 dependencies = [
  "cairo-lang-debug",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1500,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+checksum = "a483f3cbf7cec2e153d424d0e92329d816becc6421389bd494375c6065921b9b"
 dependencies = [
  "glob",
  "libc",
@@ -1540,7 +1540,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1939,7 +1939,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1972,7 +1972,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core 0.20.9",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2227,7 +2227,7 @@ checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2405,7 +2405,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.65",
+ "syn 2.0.66",
  "toml",
  "walkdir",
 ]
@@ -2422,7 +2422,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2447,7 +2447,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.2",
- "syn 2.0.65",
+ "syn 2.0.66",
  "tempfile",
  "thiserror",
  "tiny-keccak 2.0.2",
@@ -2805,7 +2805,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2876,7 +2876,7 @@ checksum = "553630feadf7b76442b0849fd25fdf89b860d933623aec9693fed19af0400c78"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3357,9 +3357,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "3d8d52be92d09acc2e01dddb7fde3ad983fc6489c7db4837e605bc3fca4cb63e"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3724,7 +3724,7 @@ dependencies = [
  "hyper 0.14.28",
  "jsonrpsee-types 0.15.1",
  "lazy_static",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "rustc-hash",
  "serde",
@@ -3750,7 +3750,7 @@ dependencies = [
  "futures-util",
  "hyper 0.14.28",
  "jsonrpsee-types 0.22.5",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "rustc-hash",
  "serde",
@@ -3820,7 +3820,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4379,7 +4379,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4457,7 +4457,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4551,9 +4551,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core 0.9.10",
@@ -4657,7 +4657,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4731,7 +4731,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4775,7 +4775,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4850,7 +4850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4925,9 +4925,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.83"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
+checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -4940,7 +4940,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
  "version_check",
  "yansi 1.0.1",
 ]
@@ -5418,7 +5418,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.65",
+ "syn 2.0.66",
  "unicode-ident",
 ]
 
@@ -5674,9 +5674,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0218ceea14babe24a4a5836f86ade86c1effbc198164e619194cb5069187e29"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
@@ -5687,14 +5687,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed5a1ccce8ff962e31a165d41f6e2a2dd1245099dc4d594f5574a86cd90f4d3"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5803,22 +5803,22 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5829,7 +5829,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5911,7 +5911,7 @@ dependencies = [
  "darling 0.20.9",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6285,7 +6285,7 @@ checksum = "bbc159a1934c7be9761c237333a57febe060ace2bc9e3b337a59a37af206d19f"
 dependencies = [
  "starknet-curve 0.4.2",
  "starknet-ff",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6328,7 +6328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95d549d3078bdbe775d0deaa8ddb57a19942989ce7c1f2dfd60beeb322bb4945"
 dependencies = [
  "starknet-core",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6401,7 +6401,7 @@ checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "phf_shared 0.10.0",
  "precomputed-hash",
 ]
@@ -6459,7 +6459,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6528,9 +6528,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.65"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6616,7 +6616,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6733,7 +6733,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -6748,7 +6748,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6938,7 +6938,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -7225,7 +7225,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -7298,7 +7298,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -7332,7 +7332,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7703,7 +7703,7 @@ checksum = "0f22d6a02cbc84ea1993b0b341833a55a0866a3378c3a76e0ca664bc2574e370"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot 0.12.2",
+ "parking_lot 0.12.3",
  "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -7727,14 +7727,14 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]
@@ -7747,7 +7747,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/crates/experimental-api/src/exe/err.rs
+++ b/crates/experimental-api/src/exe/err.rs
@@ -12,7 +12,7 @@ pub enum Error {
     #[error("reqwest error: {0:?}")]
     Reqwest(#[from] reqwest::Error),
     #[error("codegen error: {0:?}")]
-    IamGroot(iamgroot::jsonrpc::Error),
+    IamGroot(#[from] iamgroot::jsonrpc::Error),
     #[error("starknet api error: {0:?}")]
     StarknetApi(#[from] starknet_api::StarknetApiError),
     #[error("blockifier state error: {0:?}")]
@@ -29,12 +29,6 @@ pub enum Error {
     SierraCompilation(#[from] StarknetSierraCompilationError),
     #[error("{0}")]
     Custom(&'static str),
-}
-
-impl From<iamgroot::jsonrpc::Error> for Error {
-    fn from(error: iamgroot::jsonrpc::Error) -> Self {
-        Self::IamGroot(error)
-    }
 }
 
 impl From<Error> for blockifier::state::errors::StateError {

--- a/crates/experimental-api/tests/exe.rs
+++ b/crates/experimental-api/tests/exe.rs
@@ -5,12 +5,11 @@ use beerus_experimental_api::{
 
 mod common;
 
+use common::Error;
+
 #[test]
-fn test_call_deprecated_contract_class() -> Result<(), common::Error> {
-    let Ok(url) = std::env::var("BEERUS_EXPERIMENTAL_TEST_STARKNET_URL") else {
-        return Ok(());
-    };
-    let client = Client::new(&url);
+fn test_call_deprecated_contract_class() -> Result<(), Error> {
+    let client = client!();
     tracing_subscriber::fmt::try_init().ok();
 
     // TX: 0xcbb2b87d5378e682d650e0e7d36679b4557ba2bfa9d4e285b7168c04376b21
@@ -42,11 +41,8 @@ fn test_call_deprecated_contract_class() -> Result<(), common::Error> {
 }
 
 #[test]
-fn test_call_regular_contract_class() -> Result<(), common::Error> {
-    let Ok(url) = std::env::var("BEERUS_EXPERIMENTAL_TEST_STARKNET_URL") else {
-        return Ok(());
-    };
-    let client = Client::new(&url);
+fn test_call_regular_contract_class() -> Result<(), Error> {
+    let client = client!();
     tracing_subscriber::fmt::try_init().ok();
 
     let json = serde_json::json!({

--- a/crates/experimental-api/tests/rpc.rs
+++ b/crates/experimental-api/tests/rpc.rs
@@ -1,39 +1,20 @@
-use beerus_experimental_api::{
-    gen::client::Client,
-    gen::{
-        Address, BlockId, BlockNumber, BlockTag, BroadcastedInvokeTxn,
-        BroadcastedTxn, Felt, FunctionCall, GetBlockWithTxHashesResult,
-        GetBlockWithTxsResult, GetClassAtResult, GetClassResult,
-        GetTransactionByBlockIdAndIndexIndex, GetTransactionReceiptResult,
-        InvokeTxn, InvokeTxnV1, InvokeTxnV1Version, PriceUnit, Rpc, StorageKey,
-        SyncingResult, Txn, TxnExecutionStatus, TxnHash, TxnReceipt, TxnStatus,
-    },
-    rpc::{serve, Server},
+use beerus_experimental_api::gen::{
+    Address, BlockId, BlockNumber, BlockTag, BroadcastedInvokeTxn,
+    BroadcastedTxn, Felt, FunctionCall, GetBlockWithTxHashesResult,
+    GetBlockWithTxsResult, GetClassAtResult, GetClassResult,
+    GetTransactionByBlockIdAndIndexIndex, GetTransactionReceiptResult,
+    InvokeTxn, InvokeTxnV1, InvokeTxnV1Version, PriceUnit, Rpc, StorageKey,
+    SyncingResult, Txn, TxnExecutionStatus, TxnHash, TxnReceipt, TxnStatus,
 };
 
 mod common;
 
-pub struct Context {
-    pub client: Client,
-    pub server: Server,
-}
-
-pub async fn ctx() -> Option<Context> {
-    let url = std::env::var("BEERUS_EXPERIMENTAL_TEST_STARKNET_URL").ok()?;
-    let server = serve(&url, "127.0.0.1:0").await.ok()?;
-    tracing::info!(port = server.port(), "test server is up");
-
-    let url = format!("http://localhost:{}/rpc", server.port());
-    let client = Client::new(&url);
-    Some(Context { server, client })
-}
+use common::Error;
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_specVersion() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_specVersion() -> Result<(), Error> {
+    let ctx = setup!();
 
     let ret = ctx.client.specVersion().await?;
     assert_eq!(ret, "0.6.0");
@@ -42,10 +23,8 @@ async fn test_specVersion() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_chainId() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_chainId() -> Result<(), Error> {
+    let ctx = setup!();
 
     let ret = ctx.client.chainId().await?;
     assert_eq!(ret.as_ref(), "0x534e5f4d41494e");
@@ -54,10 +33,8 @@ async fn test_chainId() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_blockHashAndNumber() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_blockHashAndNumber() -> Result<(), Error> {
+    let ctx = setup!();
 
     let ret = ctx.client.blockHashAndNumber().await?;
     assert!(*ret.block_number.as_ref() > 600612);
@@ -67,10 +44,8 @@ async fn test_blockHashAndNumber() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_blockNumber() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_blockNumber() -> Result<(), Error> {
+    let ctx = setup!();
 
     let ret = ctx.client.blockNumber().await?;
     assert!(*ret.as_ref() > 600612);
@@ -79,10 +54,8 @@ async fn test_blockNumber() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_call() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_call() -> Result<(), Error> {
+    let ctx = setup!();
 
     let request = FunctionCall {
         calldata: Vec::default(),
@@ -105,10 +78,8 @@ async fn test_call() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_estimateFee() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_estimateFee() -> Result<(), Error> {
+    let ctx = setup!();
 
     let calldata = vec![
         "0x2",
@@ -169,10 +140,8 @@ async fn test_estimateFee() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_getBlockTransactionCount() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_getBlockTransactionCount() -> Result<(), Error> {
+    let ctx = setup!();
 
     let block_id = BlockId::BlockTag(BlockTag::Latest);
 
@@ -183,10 +152,8 @@ async fn test_getBlockTransactionCount() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_getBlockWithTxHashes() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_getBlockWithTxHashes() -> Result<(), Error> {
+    let ctx = setup!();
 
     let block_id = BlockId::BlockTag(BlockTag::Latest);
 
@@ -201,10 +168,8 @@ async fn test_getBlockWithTxHashes() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_getBlockWithTxs() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_getBlockWithTxs() -> Result<(), Error> {
+    let ctx = setup!();
 
     let block_id = BlockId::BlockTag(BlockTag::Latest);
 
@@ -219,10 +184,8 @@ async fn test_getBlockWithTxs() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_syncing() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_syncing() -> Result<(), Error> {
+    let ctx = setup!();
 
     let ret = ctx.client.syncing().await?;
     assert!(matches!(ret, SyncingResult::SyncStatus(_)));
@@ -231,10 +194,8 @@ async fn test_syncing() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_getNonce() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_getNonce() -> Result<(), Error> {
+    let ctx = setup!();
 
     let block_id = BlockId::BlockTag(BlockTag::Latest);
 
@@ -249,10 +210,8 @@ async fn test_getNonce() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_getTransactionByHash() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_getTransactionByHash() -> Result<(), Error> {
+    let ctx = setup!();
 
     let hash =
         "0x2e2a98c1731ece2691edfbb4ed9b057182cec569735bd89825f17e3b342583a";
@@ -267,10 +226,8 @@ async fn test_getTransactionByHash() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_getTransactionByBlockIdAndIndex() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_getTransactionByBlockIdAndIndex() -> Result<(), Error> {
+    let ctx = setup!();
 
     let block_id = BlockId::BlockTag(BlockTag::Latest);
 
@@ -284,10 +241,8 @@ async fn test_getTransactionByBlockIdAndIndex() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_getStorageAt() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_getStorageAt() -> Result<(), Error> {
+    let ctx = setup!();
 
     let contract_address = Address(Felt::try_new(
         "0x6a05844a03bb9e744479e3298f54705a35966ab04140d3d8dd797c1f6dc49d0",
@@ -307,10 +262,8 @@ async fn test_getStorageAt() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_getProof() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_getProof() -> Result<(), Error> {
+    let ctx = setup!();
 
     let contract_address = Address(Felt::try_new(
         "0x49D36570D4e46f48e99674bd3fcc84644DdD6b96F7C741B1562B82f9e004dC7",
@@ -338,10 +291,8 @@ async fn test_getProof() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_getTransactionStatus() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_getTransactionStatus() -> Result<(), Error> {
+    let ctx = setup!();
 
     let transaction_hash = TxnHash(Felt::try_new(
         "0x2e2a98c1731ece2691edfbb4ed9b057182cec569735bd89825f17e3b342583a",
@@ -358,10 +309,8 @@ async fn test_getTransactionStatus() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_getTransactionReceipt() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_getTransactionReceipt() -> Result<(), Error> {
+    let ctx = setup!();
 
     let hash =
         "0x4c1672e824b5cd7477fca31ee3ab5a1058534ed1820bb27abc976c2e6095151";
@@ -381,10 +330,8 @@ async fn test_getTransactionReceipt() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_getClass() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_getClass() -> Result<(), Error> {
+    let ctx = setup!();
 
     let block_id = BlockId::BlockTag(BlockTag::Latest);
 
@@ -415,10 +362,8 @@ async fn test_getClass() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_getClassAt() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_getClassAt() -> Result<(), Error> {
+    let ctx = setup!();
 
     let block_id = BlockId::BlockTag(BlockTag::Latest);
 
@@ -446,10 +391,8 @@ async fn test_getClassAt() -> Result<(), common::Error> {
 
 #[tokio::test]
 #[allow(non_snake_case)]
-async fn test_getClassHashAt() -> Result<(), common::Error> {
-    let Some(ctx) = ctx().await else {
-        return Ok(());
-    };
+async fn test_getClassHashAt() -> Result<(), Error> {
+    let ctx = setup!();
 
     let block_id = BlockId::BlockTag(BlockTag::Latest);
 

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -4,9 +4,6 @@ edition = "2021"
 name = "beerus-rpc"
 version = "0.4.0"
 
-[features]
-integration-tests = ["pretty_assertions", "reqwest", "serde_json", "tokio"]
-
 [dependencies]
 beerus-core = { path = "../core" }
 starknet.workspace = true
@@ -21,10 +18,10 @@ serde_with.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-# Integration test dependencies
-pretty_assertions = { version = "1.4.0", optional = true }
-reqwest = { version = "0.12.3", optional = true }
-serde_json = { version = "1.0", optional = true }
-tokio = { workspace = true, optional = true }
+[dev-dependencies]
+pretty_assertions = "1.4.0"
+reqwest = "0.12.13"
+serde_json = "1.0"
+tokio.workspace = true
 futures = "0.3.30"
 pin-utils = "0.1.0"

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -20,7 +20,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"
-reqwest = "0.12.13"
+reqwest = "0.12.3"
 serde_json = "1.0"
 tokio.workspace = true
 futures = "0.3.30"

--- a/crates/rpc/tests/rpc.rs
+++ b/crates/rpc/tests/rpc.rs
@@ -1,6 +1,3 @@
-// These tests need Beerus to run in the background, hence why they're hidden behind the following feature.
-#![cfg(feature = "integration-tests")]
-
 use reqwest::Url;
 use starknet::{
     core::types::{
@@ -12,9 +9,8 @@ use starknet::{
     providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider},
 };
 
-const TEST_RPC_URL: &str = "http://localhost:3030";
-
 fn rpc_client() -> JsonRpcClient<HttpTransport> {
+    const TEST_RPC_URL: &str = "http://localhost:3030";
     let url: Url = TEST_RPC_URL.try_into().expect("Invalid RPC URL");
     JsonRpcClient::new(HttpTransport::new(url))
 }
@@ -123,15 +119,31 @@ mod fixtures {
     }
 }
 
+#[macro_export]
+macro_rules! setup {
+    () => {{
+        let run: bool = std::env::var("BEERUS_INTEGRATION_TEST_RUN")
+            .ok()
+            .map(|value| &value == "1")
+            .unwrap_or_default();
+        if !run {
+            return;
+        }
+
+        // TODO(#648): check that Beerus is up and running (GET /ready)
+    }};
+}
+
 #[tokio::test]
 async fn test_chain_id() {
+    setup!();
     let client = rpc_client();
-
     client.chain_id().await.expect("chainId failed");
 }
 
 #[tokio::test]
 async fn test_get_block_transaction_count() {
+    setup!();
     let (client, block, block_id) = fixtures::latest_block().await;
 
     let tx_count = client
@@ -143,6 +155,7 @@ async fn test_get_block_transaction_count() {
 
 #[tokio::test]
 async fn test_get_block_with_tx_hashes() {
+    setup!();
     let (client, block, block_id) = fixtures::block_with_min_ten_txs().await;
 
     let BlockWithTxHashes {
@@ -187,6 +200,7 @@ async fn test_get_block_with_tx_hashes() {
 
 #[tokio::test]
 async fn test_get_class() {
+    setup!();
     let (block, tx_hash) = blocks::map(
         |block| {
             block.transactions.iter().find_map(
@@ -219,6 +233,7 @@ async fn test_get_class() {
 
 #[tokio::test]
 async fn test_get_class_at() {
+    setup!();
     let (block, tx_hash) = blocks::map(
         |block| {
             block.transactions.iter().find_map(
@@ -256,6 +271,7 @@ async fn test_get_class_at() {
 
 #[tokio::test]
 async fn test_get_class_hash_at() {
+    setup!();
     let (block, tx_hash) = blocks::map(
         |block| {
             block.transactions.iter().find_map(
@@ -293,6 +309,7 @@ async fn test_get_class_hash_at() {
 
 #[tokio::test]
 async fn test_get_nonce() {
+    setup!();
     let client = rpc_client();
     let (block, (nonce, sender)) = blocks::map(
         |block| {
@@ -326,6 +343,7 @@ async fn test_get_nonce() {
 
 #[tokio::test]
 async fn test_get_transaction_by_block_id_and_index() {
+    setup!();
     let (client, block, block_id) = fixtures::block_with_min_ten_txs().await;
 
     async fn check_transaction(
@@ -355,6 +373,7 @@ async fn test_get_transaction_by_block_id_and_index() {
 
 #[tokio::test]
 async fn test_get_transaction_by_hash() {
+    setup!();
     let (client, block, _) = fixtures::block_with_min_ten_txs().await;
 
     async fn check_transaction(
@@ -382,6 +401,7 @@ async fn test_get_transaction_by_hash() {
 
 #[tokio::test]
 async fn test_get_transaction_status() {
+    setup!();
     let (client, block, _) = fixtures::block_with_min_ten_txs().await;
 
     async fn check_transaction(


### PR DESCRIPTION
This PR introduces macro fixtures (that allow less boilerplate code) and an env-variable that enforces running of the tests under `experimental-api` crate.

Going further, the env-var based approach allows making sure that tests are always compiled and always run according to the environment variables being set, which potentially gives better maintainability and flexibility compared to conditional compilation based test selection.