### PR TITLE
chore(deps): enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "12:00"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    reviewers:
+      - "eigerco/beerus"


### PR DESCRIPTION
This PR adds configuration to the repository so that Dependabot automatically updates the packages we use.

[Documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates)