### PR TITLE
feat: proof validation implemented in experimental-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.22.1",
+ "beerus-core",
  "blockifier",
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/crates/cli/src/bin/beerus-experimental.rs
+++ b/crates/cli/src/bin/beerus-experimental.rs
@@ -1,4 +1,5 @@
 use beerus_cli::{get_config, Args};
+use beerus_core::client::BeerusClient;
 
 use clap::Parser;
 
@@ -8,11 +9,15 @@ async fn main() -> eyre::Result<()> {
     let config = get_config(Args::parse())?;
     config.validate_params().await?;
 
+    let mut beerus = BeerusClient::new(&config).await?;
+    beerus.start().await?;
+
     #[cfg(feature = "experimental")]
     {
         let server = beerus_experimental_api::rpc::serve(
             &config.starknet_rpc,
             &config.rpc_addr,
+            beerus.node.clone(),
         )
         .await?;
         tracing::info!(port = server.port(), "experimental rpc server started");

--- a/crates/core/src/storage_proofs/mod.rs
+++ b/crates/core/src/storage_proofs/mod.rs
@@ -178,3 +178,368 @@ impl StorageProof {
         Some(hold)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use starknet_crypto::FieldElement;
+
+    use crate::{
+        storage_proofs::{
+            types::{ContractData, TrieNode},
+            StorageProof,
+        },
+        utils::felt_to_bits,
+    };
+
+    #[test]
+    fn valid_one_level_parse_proof() {
+        let key = felt_to_bits(
+            FieldElement::from_str(
+                "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1",
+            )
+            .unwrap(),
+        );
+        let value = FieldElement::from_str(
+            "0x000000000000000000000000000047616d65206f66204c69666520546f6b656e",
+        )
+        .unwrap();
+        let edge_node_string = r#"[{
+            "edge": {
+                "child": "0x47616d65206f66204c69666520546f6b656e",
+                "path": {
+                    "len": 231,
+                    "value": "0x3dfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1"
+                }
+            }
+        }]"#;
+        let mut proof: Vec<TrieNode> =
+            serde_json::from_str(edge_node_string).unwrap();
+
+        let value = StorageProof::parse_proof(&key, value, &mut proof).unwrap();
+        assert_eq!(
+            value,
+            FieldElement::from_hex_be(
+                "0x1e224db31dfb3e1b8c95670a12f1903d4a32ac7bb83f4b209029e14155bbca9"
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn valid_five_level_parse_proof() {
+        let key = felt_to_bits(
+            FieldElement::from_str(
+                "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1",
+            )
+            .unwrap(),
+        );
+        let value = FieldElement::from_str(
+            "0x000000000000000000000000000047616d65206f66204c69666520546f6b656e",
+        )
+        .unwrap();
+        let proof_string = r#"[
+        {
+            "binary": {
+                "left": "0x46e82293b0564764a071f1aa4488aa7577b1b5bb2e898321f8536d5593d371d",
+                "right": "0x58adcf6ea8b96992aa316e2f092f2480ca406c3630fe97573046a32900745b5"
+            }
+        },
+        {
+            "binary": {
+                "left": "0x716e211c75f4c0e14dbe46c361812b0129abd061b63faf91ad5569bf22b785c",
+                "right": "0x3729d9699d4410223e413f3b3aa91a043d94242f888188036e6ea25b6962041"
+            }
+        },
+        {
+            "edge": {
+                "child": "0x6281e42b5941ae1a77ea03836aad1190097f72e1a1ed534fae2e00b4118f504",
+                "path": {
+                    "len": 1,
+                    "value": "0x1"
+                }
+            }
+        },
+        {
+            "binary": {
+                "left": "0x3e3800516f62800ef6491b1cb1915b3353026ea6a6afcf35e8d4c54e35b04ea",
+                "right": "0x1e224db31dfb3e1b8c95670a12f1903d4a32ac7bb83f4b209029e14155bbca9"
+            }
+        },
+        {
+            "edge": {
+                "child": "0x47616d65206f66204c69666520546f6b656e",
+                "path": {
+                    "len": 231,
+                    "value": "0x3dfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1"
+                }
+            }
+        }]"#;
+        let mut proof: Vec<TrieNode> =
+            serde_json::from_str(proof_string).unwrap();
+
+        let value = StorageProof::parse_proof(&key, value, &mut proof).unwrap();
+        assert_eq!(
+            value,
+            FieldElement::from_hex_be(
+                "0x6cc50a732b4256f7b642348e19bd1a8bee7ac76bed3fcee3bc34309538c00c6"
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn invalid_one_level_parse_proof() {
+        let key = felt_to_bits(FieldElement::default());
+        let value = FieldElement::ZERO;
+        let mut proof: Vec<TrieNode> = serde_json::from_str(
+            r#"[{
+            "edge": {
+                "child": "0xfaa",
+                "path": {
+                    "len": 1,
+                    "value": "0xbad"
+                }
+            }
+        }]"#,
+        )
+        .unwrap();
+        assert!(StorageProof::parse_proof(&key, value, &mut proof).is_none());
+    }
+
+    #[test]
+    fn invalid_one_level_proof_last_key_byte_2_instead_of_1() {
+        let key = felt_to_bits(
+            FieldElement::from_str(
+                "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be2",
+            )
+            .unwrap(),
+        );
+        let value = FieldElement::from_str(
+            "0x000000000000000000000000000047616d65206f66204c69666520546f6b656e",
+        )
+        .unwrap();
+        let edge_node_string = r#"[{
+            "edge": {
+                "child": "0x47616d65206f66204c69666520546f6b656e",
+                "path": {
+                    "len": 231,
+                    "value": "0x3dfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1"
+                }
+            }
+        }]"#;
+        let mut proof: Vec<TrieNode> =
+            serde_json::from_str(edge_node_string).unwrap();
+        assert!(StorageProof::parse_proof(&key, value, &mut proof).is_none());
+    }
+
+    #[test]
+    fn invalid_five_level_proof_len_7_instead_of_1() {
+        let key = felt_to_bits(
+            FieldElement::from_str(
+                "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1",
+            )
+            .unwrap(),
+        );
+        let value = FieldElement::from_str(
+            "0x000000000000000000000000000047616d65206f66204c69666520546f6b656e",
+        )
+        .unwrap();
+        let proof_string = r#"[
+        {
+            "binary": {
+                "left": "0x46e82293b0564764a071f1aa4488aa7577b1b5bb2e898321f8536d5593d371d",
+                "right": "0x58adcf6ea8b96992aa316e2f092f2480ca406c3630fe97573046a32900745b5"
+            }
+        },
+        {
+            "binary": {
+                "left": "0x716e211c75f4c0e14dbe46c361812b0129abd061b63faf91ad5569bf22b785c",
+                "right": "0x3729d9699d4410223e413f3b3aa91a043d94242f888188036e6ea25b6962041"
+            }
+        },
+        {
+            "edge": {
+                "child": "0x6281e42b5941ae1a77ea03836aad1190097f72e1a1ed534fae2e00b4118f504",
+                "path": {
+                    "len": 7,
+                    "value": "0x1"
+                }
+            }
+        },
+        {
+            "binary": {
+                "left": "0x3e3800516f62800ef6491b1cb1915b3353026ea6a6afcf35e8d4c54e35b04ea",
+                "right": "0x1e224db31dfb3e1b8c95670a12f1903d4a32ac7bb83f4b209029e14155bbca9"
+            }
+        },
+        {
+            "edge": {
+                "child": "0x47616d65206f66204c69666520546f6b656e",
+                "path": {
+                    "len": 231,
+                    "value": "0x3dfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1"
+                }
+            }
+        }]"#;
+        let mut proof: Vec<TrieNode> =
+            serde_json::from_str(proof_string).unwrap();
+        assert!(StorageProof::parse_proof(&key, value, &mut proof).is_none());
+    }
+
+    #[test]
+    fn valid_one_level_verify_proof() {
+        let mut storage_proof = StorageProof {
+            contract_data: ContractData {
+                storage_proofs: vec![serde_json::from_str(
+                    r#"[{
+                    "edge": {
+                        "child": "0x47616d65206f66204c69666520546f6b656e",
+                        "path": {
+                            "len": 231,
+                            "value": "0x3dfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1"
+                        }
+                    }
+                }]"#,
+                )
+                .unwrap()],
+                root: FieldElement::from_hex_be(
+                    "0x1e224db31dfb3e1b8c95670a12f1903d4a32ac7bb83f4b209029e14155bbca9",
+                )
+                .unwrap(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let key = felt_to_bits(
+            FieldElement::from_str(
+                "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1",
+            )
+            .unwrap(),
+        );
+        let value = FieldElement::from_str(
+            "0x000000000000000000000000000047616d65206f66204c69666520546f6b656e",
+        )
+        .unwrap();
+
+        assert!(storage_proof.verify_storage_proofs(&key, value).is_ok());
+    }
+
+    #[test]
+    fn invalid_one_level_verify_proof() {
+        let mut storage_proof = StorageProof {
+            contract_data: ContractData {
+                storage_proofs: vec![serde_json::from_str(
+                    r#"[{
+                    "edge": {
+                        "child": "0xbad",
+                        "path": {
+                            "len": 231,
+                            "value": "0xfaa"
+                        }
+                    }
+                }]"#,
+                )
+                .unwrap()],
+                root: FieldElement::from_dec_str("42").unwrap(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let key = felt_to_bits(FieldElement::default());
+        let value = FieldElement::ONE;
+
+        assert!(storage_proof.verify_storage_proofs(&key, value).is_err());
+    }
+
+    #[test]
+    fn contract_state_hash_is_valid() {
+        let storage_proof = StorageProof {
+            contract_data: ContractData {
+                class_hash: FieldElement::ONE,
+                root: FieldElement::TWO,
+                nonce: FieldElement::THREE,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_eq!(
+            storage_proof.calculate_contract_state_hash(),
+            FieldElement::from_hex_be(
+                "0x7fdeb85518534a06e6b50c2ccdea7bbf3d47c607a9b36fbf690c41274976950"
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn calculate_global_root_is_valid() {
+        let storage_proof = StorageProof {
+            class_commitment: FieldElement::ONE,
+            ..Default::default()
+        };
+        assert_eq!(
+            storage_proof.calculate_global_root(FieldElement::TWO),
+            FieldElement::from_hex_be(
+                "0x57e17712cba54d27d07c13c60861ccb7aa16fa4cfad71845d63a4448203953c"
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn valid_verify_contract_proof() {
+        let mut storage_proof = StorageProof {
+            contract_proof: serde_json::from_str(
+                r#"[{
+                "edge": {
+                    "child": "0x538a7653ef22e217f93066ac54784c0159a5e1e37d808f83c82d1b42d57457d",
+                    "path": {
+                        "len": 229,
+                        "value": "0x4a03bb9e744479e3298f54705a35966ab04140d3d8dd797c1f6dc49d0"
+                    }
+                }
+            }]"#,
+            )
+            .unwrap(),
+            state_commitment: FieldElement::from_hex_be(
+                "0x1e2a7a7ee40c1d897c8c0a9515720ea02c8075ee9e00db277f5f8c3e4edcb54",
+            )
+            .unwrap(),
+            contract_data: ContractData {
+                class_hash: FieldElement::from_hex_be(
+                    "0x4e635d495504b31ec191cbfc3d99b5d109bfcae4d0d9e16f4909a43b2e24c07",
+                )
+                .unwrap(),
+                root: FieldElement::from_hex_be(
+                    "0x5826149cbab3f8538d346301869ba2742a159d1542463ce19a60a927b826a2f",
+                )
+                .unwrap(),
+                nonce: FieldElement::ZERO,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let global_root = storage_proof.state_commitment;
+        let contract_address = FieldElement::from_hex_be(
+            "0x06a05844a03bb9e744479e3298f54705a35966ab04140d3d8dd797c1f6dc49d0",
+        )
+        .unwrap();
+        assert!(storage_proof
+            .verify_contract_proof(global_root, contract_address)
+            .is_ok());
+    }
+
+    #[test]
+    fn invalid_verify_contract_proof() {
+        let mut invalid_storage_proof = StorageProof::default();
+        let global_root = FieldElement::ZERO;
+        let contract_address = FieldElement::ZERO;
+        assert!(invalid_storage_proof
+            .verify_contract_proof(global_root, contract_address)
+            .is_err());
+    }
+}

--- a/crates/core/src/storage_proofs/types.rs
+++ b/crates/core/src/storage_proofs/types.rs
@@ -7,7 +7,7 @@ use super::StorageProof;
 
 /// Holds the data and proofs for a specific contract.
 #[serde_as]
-#[derive(Debug, PartialEq, Deserialize, Clone, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Clone, Serialize, Default)]
 pub struct ContractData {
     /// Required to verify the contract state hash to contract root calculation.
     #[serde_as(as = "UfeHex")]

--- a/crates/core/src/utils.rs
+++ b/crates/core/src/utils.rs
@@ -20,7 +20,15 @@ pub fn felt_from_bits(
         return Err(eyre!("expecting 251 bits"));
     }
 
-    let mask = if let Some(x) = mask { x } else { 0 };
+    let mask = match mask {
+        Some(x) => {
+            if x > 251 {
+                return Err(eyre!("Mask cannot be bigger than 251"));
+            }
+            x
+        }
+        None => 0,
+    };
 
     let mut bytes = [0u8; 32];
     bytes.view_bits_mut::<Msb0>()[5 + mask..].copy_from_bitslice(&bits[mask..]);

--- a/crates/core/src/utils.rs
+++ b/crates/core/src/utils.rs
@@ -50,3 +50,93 @@ pub fn simple_call_opts(addr: Address, data: Bytes) -> CallOpts {
 pub fn get_balance_key(addr: FieldElement) -> FieldElement {
     get_storage_var_address(ERC20_BALANCES_BASE, &[addr]).unwrap()
 }
+
+#[cfg(test)]
+mod tests {
+    use bitvec::{order::Msb0, slice::BitSlice};
+    use starknet_crypto::FieldElement;
+
+    use crate::utils::{felt_from_bits, felt_to_bits, get_balance_key};
+
+    #[test]
+    fn test_felt_to_bits_three() {
+        let val = FieldElement::THREE;
+        let mut slice = [0u8; 32];
+        let bit_slice = BitSlice::<u8, Msb0>::from_slice_mut(&mut slice);
+        bit_slice.set(249, true);
+        bit_slice.set(250, true);
+        assert_eq!(felt_to_bits(val), &bit_slice[..251]);
+    }
+
+    #[test]
+    fn test_felt_to_bits_fourteen() {
+        let val = FieldElement::from_dec_str("14").unwrap();
+        let mut slice = [0u8; 32];
+        let bit_slice = BitSlice::<u8, Msb0>::from_slice_mut(&mut slice);
+        bit_slice.set(247, true);
+        bit_slice.set(248, true);
+        bit_slice.set(249, true);
+        assert_eq!(felt_to_bits(val), &bit_slice[..251]);
+    }
+
+    #[test]
+    fn test_felt_from_bits_one() {
+        let mut slice = [0u8; 32];
+        let bit_slice = BitSlice::<u8, Msb0>::from_slice_mut(&mut slice);
+        bit_slice.set(250, true);
+        assert_eq!(
+            felt_from_bits(&bit_slice[..251], None).unwrap(),
+            FieldElement::ONE
+        );
+    }
+
+    #[test]
+    fn test_felt_from_bits_seven() {
+        let mut slice = [0u8; 32];
+        let bit_slice = BitSlice::<u8, Msb0>::from_slice_mut(&mut slice);
+        bit_slice.set(248, true);
+        bit_slice.set(249, true);
+        bit_slice.set(250, true);
+        assert_eq!(
+            felt_from_bits(&bit_slice[..251], None).unwrap(),
+            FieldElement::from_dec_str("7").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_felt_from_bits_mask() {
+        let mut slice = [0u8; 32];
+        let bit_slice = BitSlice::<u8, Msb0>::from_slice_mut(&mut slice);
+        bit_slice.set(0, true);
+        bit_slice.set(250, true);
+        assert_eq!(
+            felt_from_bits(&bit_slice[..251], None).unwrap(),
+            FieldElement::from_dec_str(
+                "1809251394333065553493296640760748560207343510400633813116524750123642650625"
+            )
+            .unwrap()
+        );
+        assert_eq!(
+            felt_from_bits(&bit_slice[..251], Some(1)).unwrap(),
+            FieldElement::from_dec_str("1").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_felt_from_bits_wrong_mask_value() {
+        let mut slice = [0u8; 32];
+        let bit_slice = BitSlice::<u8, Msb0>::from_slice_mut(&mut slice);
+        assert!(felt_from_bits(&bit_slice[..251], Some(252)).is_err());
+    }
+
+    #[test]
+    fn test_get_balance_key() {
+        assert_eq!(
+            get_balance_key(FieldElement::ONE),
+            FieldElement::from_dec_str(
+                "3488041066649332616440110253331181934927363442882040970594983370166361489161"
+            )
+            .unwrap()
+        );
+    }
+}

--- a/crates/experimental-api/Cargo.toml
+++ b/crates/experimental-api/Cargo.toml
@@ -32,5 +32,7 @@ flate2 = "1.0.28"
 cairo-lang-starknet-classes = "2.6.3"
 ureq = { version = "2.9.6", features = ["json"] }
 
+beerus-core = { path = "../core" }
+
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/crates/experimental-api/src/gen.rs
+++ b/crates/experimental-api/src/gen.rs
@@ -9,19 +9,9 @@ pub mod gen {
     use serde_json::Value;
 
     use iamgroot::jsonrpc;
-    use starknet_crypto::{pedersen_hash, poseidon_hash_many, FieldElement};
-
-    use beerus_core::storage_proofs::types::Direction;
-    use beerus_core::utils::{felt_from_bits, felt_to_bits};
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct Address(pub Felt);
-
-    impl From<Address> for String {
-        fn from(value: Address) -> String {
-            value.0 .0
-        }
-    }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct BinaryNode {
@@ -44,7 +34,7 @@ pub mod gen {
         pub transactions: Vec<BlockTransaction>,
     }
 
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub struct BlockHash(pub Felt);
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -102,7 +92,7 @@ pub mod gen {
         }
     }
 
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     #[serde(untagged)]
     pub enum BlockId {
         BlockHash { block_hash: BlockHash },
@@ -110,9 +100,9 @@ pub mod gen {
         BlockTag(BlockTag),
     }
 
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     #[serde(try_from = "i64")]
-    pub struct BlockNumber(pub i64);
+    pub struct BlockNumber(i64);
 
     mod blocknumber {
         use super::jsonrpc;
@@ -169,7 +159,7 @@ pub mod gen {
         Rejected,
     }
 
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     pub enum BlockTag {
         #[serde(rename = "latest")]
         Latest,
@@ -964,14 +954,13 @@ pub mod gen {
         pub unit: PriceUnit,
     }
 
-    #[derive(Clone, Debug, Deserialize, Serialize, Default, PartialEq)]
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
     #[serde(try_from = "String")]
     pub struct Felt(String);
 
     mod felt {
         use super::jsonrpc;
         use super::Felt;
-        use crate::gen::Address;
         use once_cell::sync::Lazy;
         use regex::Regex;
 
@@ -1005,12 +994,6 @@ pub mod gen {
         impl AsRef<String> for Felt {
             fn as_ref(&self) -> &String {
                 &self.0
-            }
-        }
-
-        impl From<Address> for Felt {
-            fn from(value: Address) -> Self {
-                value.0
             }
         }
     }
@@ -1676,12 +1659,6 @@ pub mod gen {
                 &self.0
             }
         }
-
-        impl From<StorageKey> for String {
-            fn from(value: StorageKey) -> Self {
-                value.0
-            }
-        }
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2160,7 +2137,7 @@ pub mod gen {
         pub transaction_hash: Option<Felt>,
     }
 
-    #[derive(Clone, Debug, Deserialize, Serialize, Default)]
+    #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct ContractData {
         pub class_hash: Felt,
         pub contract_state_hash_version: Felt,
@@ -2171,7 +2148,7 @@ pub mod gen {
         pub storage_proofs: Option<Vec<Proof>>,
     }
 
-    #[derive(Clone, Debug, Deserialize, Serialize, Default)]
+    #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct GetProofResult {
         #[serde(skip_serializing_if = "Option::is_none")]
         #[serde(default)]
@@ -2183,312 +2160,6 @@ pub mod gen {
         #[serde(skip_serializing_if = "Option::is_none")]
         #[serde(default)]
         pub state_commitment: Option<Felt>,
-    }
-
-    impl GetProofResult {
-        pub fn verify(
-            &mut self,
-            global_root: Felt,
-            contract_address: Address,
-            key: StorageKey,
-            value: Felt,
-        ) -> Result<(), jsonrpc::Error> {
-            let contract_data =
-                self.contract_data.as_ref().ok_or(jsonrpc::Error::new(
-                    -32700,
-                    "No contract data found".to_string(),
-                ))?;
-            self.verify_storage_proofs(contract_data, key, value)?;
-            self.verify_contract_proof(
-                contract_data,
-                global_root,
-                contract_address,
-            )
-        }
-
-        fn verify_storage_proofs(
-            &self,
-            contract_data: &ContractData,
-            key: StorageKey,
-            value: Felt,
-        ) -> Result<(), jsonrpc::Error> {
-            let root = &contract_data.root;
-            let storage_proofs = &contract_data.storage_proofs.as_ref().ok_or(
-                jsonrpc::Error::new(
-                    -32700,
-                    "No storage proof found".to_string(),
-                ),
-            )?[0];
-
-            match Self::parse_proof(key, value, storage_proofs)? {
-                Some(computed_root) => match computed_root == *root {
-                    true => Ok(()),
-                    false => Err(jsonrpc::Error::new(
-                        -32700,
-                        format!(
-                            "Proof invalid:\nprovided-root -> {}\ncomputed-root -> {}\n",
-                            root.as_ref(), computed_root.as_ref()
-                        ),
-                    )),
-                },
-                None => Err(jsonrpc::Error::new(
-                    -32700,
-                    format!("Proof invalid for root -> {}\n", root.as_ref()),
-                )),
-            }
-        }
-
-        fn verify_contract_proof(
-            &self,
-            contract_data: &ContractData,
-            global_root: Felt,
-            contract_address: Address,
-        ) -> Result<(), jsonrpc::Error> {
-            let state_hash =
-                Self::calculate_contract_state_hash(contract_data)?;
-
-            match Self::parse_proof(
-                contract_address,
-                state_hash,
-                &self.contract_proof,
-            )? {
-                Some(storage_commitment) => {
-                    let class_commitment = self
-                        .class_commitment
-                        .as_ref()
-                        .ok_or(jsonrpc::Error::new(
-                            -32700,
-                            "No class commitment".to_string(),
-                        ))?;
-                    let parsed_global_root = Self::calculate_global_root(
-                        class_commitment,
-                        storage_commitment,
-                    )
-                    .map_err(|_| {
-                        jsonrpc::Error::new(
-                            -32700,
-                            "Failed to calculate global root".to_string(),
-                        )
-                    })?;
-                    let state_commitment = self
-                        .state_commitment
-                        .as_ref()
-                        .ok_or(jsonrpc::Error::new(
-                            -32700,
-                            "No state commitment".to_string(),
-                        ))?;
-                    match *state_commitment == parsed_global_root && global_root == parsed_global_root {
-                        true => Ok(()),
-                        false => Err(jsonrpc::Error::new(
-                            -32700,
-                            format!("Proof invalid:\nstate commitment -> {}\nparsed global root -> {}\n global root -> {}", 
-                            state_commitment.as_ref(), parsed_global_root.as_ref(), global_root.as_ref())
-                        )),
-                    }
-                }
-                None => Err(jsonrpc::Error::new(
-                    -32700,
-                    format!(
-                        "Could not parse global root for root: {}",
-                        global_root.as_ref()
-                    ),
-                )),
-            }
-        }
-
-        fn calculate_contract_state_hash(
-            contract_data: &ContractData,
-        ) -> Result<Felt, jsonrpc::Error> {
-            // The contract state hash is defined as H(H(H(hash, root), nonce), CONTRACT_STATE_HASH_VERSION)
-            const CONTRACT_STATE_HASH_VERSION: FieldElement =
-                FieldElement::ZERO;
-            let hash = pedersen_hash(
-                &FieldElement::from_hex_be(contract_data.class_hash.as_ref())
-                    .map_err(|_| {
-                    jsonrpc::Error::new(
-                        -32701,
-                        "Failed to create Field Element".to_string(),
-                    )
-                })?,
-                &FieldElement::from_hex_be(contract_data.root.as_ref())
-                    .map_err(|_| {
-                        jsonrpc::Error::new(
-                            -32701,
-                            "Failed to create Field Element".to_string(),
-                        )
-                    })?,
-            );
-            let hash = pedersen_hash(
-                &hash,
-                &FieldElement::from_hex_be(contract_data.nonce.as_ref())
-                    .map_err(|_| {
-                        jsonrpc::Error::new(
-                            -32701,
-                            "Failed to create Field Element".to_string(),
-                        )
-                    })?,
-            );
-            let hash = pedersen_hash(&hash, &CONTRACT_STATE_HASH_VERSION);
-            Felt::try_new(&format!("0x{:x}", hash)).map_err(|_| {
-                jsonrpc::Error::new(
-                    -32701,
-                    "Failed to create Field Element".to_string(),
-                )
-            })
-        }
-
-        fn calculate_global_root(
-            class_commitment: &Felt,
-            storage_commitment: Felt,
-        ) -> Result<Felt, jsonrpc::Error> {
-            let global_state_ver =
-                FieldElement::from_byte_slice_be(b"STARKNET_STATE_V0")
-                    .map_err(|_| {
-                        jsonrpc::Error::new(
-                            -32701,
-                            "Failed to create Field Element".to_string(),
-                        )
-                    })?;
-            let hash = poseidon_hash_many(&[
-                global_state_ver,
-                FieldElement::from_hex_be(storage_commitment.as_ref())
-                    .map_err(|_| {
-                        jsonrpc::Error::new(
-                            -32701,
-                            "Failed to create Field Element".to_string(),
-                        )
-                    })?,
-                FieldElement::from_hex_be(class_commitment.as_ref()).map_err(
-                    |_| {
-                        jsonrpc::Error::new(
-                            -32701,
-                            "Failed to create Field Element".to_string(),
-                        )
-                    },
-                )?,
-            ]);
-            Felt::try_new(&format!("0x{:x}", hash)).map_err(|_| {
-                jsonrpc::Error::new(
-                    -32701,
-                    "Failed to create Field Element".to_string(),
-                )
-            })
-        }
-
-        fn parse_proof(
-            key: impl Into<String>,
-            value: Felt,
-            proof: &[Node],
-        ) -> Result<Option<Felt>, jsonrpc::Error> {
-            let key = felt_to_bits(
-                FieldElement::from_hex_be(&key.into()).map_err(|_| {
-                    jsonrpc::Error::new(
-                        -32701,
-                        "Failed to create Field Element".to_string(),
-                    )
-                })?,
-            );
-            if key.len() != 251 {
-                return Ok(None);
-            }
-            let value =
-                FieldElement::from_hex_be(value.as_ref()).map_err(|_| {
-                    jsonrpc::Error::new(
-                        -32701,
-                        "Failed to create Field Element".to_string(),
-                    )
-                })?;
-            // initialized to the value so if the last node
-            // in the proof is a binary node we can still verify
-            let (mut hold, mut path_len) = (value, 0);
-            // reverse the proof in order to hash from the leaf towards the root
-            for (i, node) in proof.iter().rev().enumerate() {
-                match node {
-                    Node::EdgeNode(EdgeNode {
-                        edge: EdgeNodeEdge { child, path },
-                    }) => {
-                        // calculate edge hash given by provider
-                        let child_felt = FieldElement::from_hex_be(
-                            child.as_ref(),
-                        )
-                        .map_err(|_| {
-                            jsonrpc::Error::new(
-                                -32701,
-                                "Failed to create Field Element".to_string(),
-                            )
-                        })?;
-                        let path_value =
-                            FieldElement::from_hex_be(path.value.as_ref())
-                                .map_err(|_| {
-                                    jsonrpc::Error::new(
-                                        -32701,
-                                        "Failed to create Field Element"
-                                            .to_string(),
-                                    )
-                                })?;
-                        let provided_hash =
-                            pedersen_hash(&child_felt, &path_value)
-                                + FieldElement::from(path.len as u64);
-                        if i == 0 {
-                            // mask storage key
-                            let computed_hash = match felt_from_bits(
-                                &key,
-                                Some(251 - path.len as usize),
-                            ) {
-                                Ok(masked_key) => {
-                                    pedersen_hash(&value, &masked_key)
-                                        + FieldElement::from(path.len as u64)
-                                }
-                                Err(_) => return Ok(None),
-                            };
-                            // verify computed hash against provided hash
-                            if provided_hash != computed_hash {
-                                return Ok(None);
-                            };
-                        }
-
-                        // walk up the remaining path
-                        path_len += path.len;
-                        hold = provided_hash;
-                    }
-                    Node::BinaryNode(BinaryNode {
-                        binary: BinaryNodeBinary { left, right },
-                    }) => {
-                        path_len += 1;
-                        let left = FieldElement::from_hex_be(left.as_ref())
-                            .map_err(|_| {
-                                jsonrpc::Error::new(
-                                    -32701,
-                                    "Failed to create Field Element"
-                                        .to_string(),
-                                )
-                            })?;
-                        let right = FieldElement::from_hex_be(right.as_ref())
-                            .map_err(|_| {
-                            jsonrpc::Error::new(
-                                -32701,
-                                "Failed to create Field Element".to_string(),
-                            )
-                        })?;
-                        // identify path direction for this node
-                        let expected_hash =
-                            match Direction::from(key[251 - path_len as usize])
-                            {
-                                Direction::Left => pedersen_hash(&hold, &right),
-                                Direction::Right => pedersen_hash(&left, &hold),
-                            };
-
-                        hold = pedersen_hash(&left, &right);
-                        // verify calculated hash vs provided hash for the node
-                        if hold != expected_hash {
-                            return Ok(None);
-                        };
-                    }
-                };
-            }
-
-            Ok(Some(Felt::try_new(&format!("0x{:x}", hold))?))
-        }
     }
 
     pub mod error {
@@ -9820,344 +9491,6 @@ pub mod gen {
                     }
                 }
             }
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use crate::gen::{
-            Address, ContractData, Felt, GetProofResult, Node, StorageKey,
-        };
-
-        #[test]
-        fn valid_one_level_parse_proof() {
-            let key = "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1".to_string();
-            let value = Felt::try_new("0x47616d65206f66204c69666520546f6b656e")
-                .unwrap();
-            let edge_node_string = r#"[{
-                "edge": {
-                    "child": "0x47616d65206f66204c69666520546f6b656e",
-                    "path": {
-                        "len": 231,
-                        "value": "0x3dfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1"
-                    }
-                }
-            }]"#;
-            let proof: Vec<Node> =
-                serde_json::from_str(edge_node_string).unwrap();
-            let ret_val =
-                GetProofResult::parse_proof(key, value, &proof).unwrap();
-
-            assert!(ret_val.is_some());
-            let ret_val = ret_val.unwrap();
-            assert_eq!(
-                ret_val.0,
-                "0x1e224db31dfb3e1b8c95670a12f1903d4a32ac7bb83f4b209029e14155bbca9"
-            );
-        }
-
-        #[test]
-        fn valid_five_level_parse_proof() {
-            let key = "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1".to_string();
-            let value = Felt::try_new("0x47616d65206f66204c69666520546f6b656e")
-                .unwrap();
-            let proof_string = r#"[
-            {
-                "binary": {
-                    "left": "0x46e82293b0564764a071f1aa4488aa7577b1b5bb2e898321f8536d5593d371d",
-                    "right": "0x58adcf6ea8b96992aa316e2f092f2480ca406c3630fe97573046a32900745b5"
-                }
-            },
-            {
-                "binary": {
-                    "left": "0x716e211c75f4c0e14dbe46c361812b0129abd061b63faf91ad5569bf22b785c",
-                    "right": "0x3729d9699d4410223e413f3b3aa91a043d94242f888188036e6ea25b6962041"
-                }
-            },
-            {
-                "edge": {
-                    "child": "0x6281e42b5941ae1a77ea03836aad1190097f72e1a1ed534fae2e00b4118f504",
-                    "path": {
-                        "len": 1,
-                        "value": "0x1"
-                    }
-                }
-            },
-            {
-                "binary": {
-                    "left": "0x3e3800516f62800ef6491b1cb1915b3353026ea6a6afcf35e8d4c54e35b04ea",
-                    "right": "0x1e224db31dfb3e1b8c95670a12f1903d4a32ac7bb83f4b209029e14155bbca9"
-                }
-            },
-            {
-                "edge": {
-                    "child": "0x47616d65206f66204c69666520546f6b656e",
-                    "path": {
-                        "len": 231,
-                        "value": "0x3dfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1"
-                    }
-                }
-            }]"#;
-            let proof: Vec<Node> = serde_json::from_str(proof_string).unwrap();
-            let ret_val =
-                GetProofResult::parse_proof(key, value, &proof).unwrap();
-
-            assert!(ret_val.is_some());
-            let ret_val = ret_val.unwrap();
-            assert_eq!(
-                ret_val.0,
-                "0x6cc50a732b4256f7b642348e19bd1a8bee7ac76bed3fcee3bc34309538c00c6"
-            );
-        }
-
-        #[test]
-        fn invalid_one_level_parse_proof() {
-            let key = "0xabc".to_string();
-            let value = Felt::try_new("0xdef").unwrap();
-            let proof: Vec<Node> = serde_json::from_str(
-                r#"[{
-                "edge": {
-                    "child": "0xfaa",
-                    "path": {
-                        "len": 1,
-                        "value": "0xbad"
-                    }
-                }
-            }]"#,
-            )
-            .unwrap();
-            assert!(GetProofResult::parse_proof(key, value, &proof)
-                .unwrap()
-                .is_none());
-        }
-
-        #[test]
-        fn invalid_one_level_proof_last_key_byte_2_instead_of_1() {
-            let key = "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be2".to_string();
-            let value = Felt::try_new("0x47616d65206f66204c69666520546f6b656e")
-                .unwrap();
-            let edge_node_string = r#"[{
-                "edge": {
-                    "child": "0x47616d65206f66204c69666520546f6b656e",
-                    "path": {
-                        "len": 231,
-                        "value": "0x3dfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1"
-                    }
-                }
-            }]"#;
-            let proof: Vec<Node> =
-                serde_json::from_str(edge_node_string).unwrap();
-            assert!(GetProofResult::parse_proof(key, value, &proof)
-                .unwrap()
-                .is_none());
-        }
-
-        #[test]
-        fn invalid_five_level_proof_len_7_instead_of_1() {
-            let key = "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1".to_string();
-            let value = Felt::try_new("0x47616d65206f66204c69666520546f6b656e")
-                .unwrap();
-            let proof_string = r#"[
-            {
-                "binary": {
-                    "left": "0x46e82293b0564764a071f1aa4488aa7577b1b5bb2e898321f8536d5593d371d",
-                    "right": "0x58adcf6ea8b96992aa316e2f092f2480ca406c3630fe97573046a32900745b5"
-                }
-            },
-            {
-                "binary": {
-                    "left": "0x716e211c75f4c0e14dbe46c361812b0129abd061b63faf91ad5569bf22b785c",
-                    "right": "0x3729d9699d4410223e413f3b3aa91a043d94242f888188036e6ea25b6962041"
-                }
-            },
-            {
-                "edge": {
-                    "child": "0x6281e42b5941ae1a77ea03836aad1190097f72e1a1ed534fae2e00b4118f504",
-                    "path": {
-                        "len": 7,
-                        "value": "0x1"
-                    }
-                }
-            },
-            {
-                "binary": {
-                    "left": "0x3e3800516f62800ef6491b1cb1915b3353026ea6a6afcf35e8d4c54e35b04ea",
-                    "right": "0x1e224db31dfb3e1b8c95670a12f1903d4a32ac7bb83f4b209029e14155bbca9"
-                }
-            },
-            {
-                "edge": {
-                    "child": "0x47616d65206f66204c69666520546f6b656e",
-                    "path": {
-                        "len": 231,
-                        "value": "0x3dfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1"
-                    }
-                }
-            }]"#;
-            let proof: Vec<Node> = serde_json::from_str(proof_string).unwrap();
-            assert!(GetProofResult::parse_proof(key, value, &proof)
-                .unwrap()
-                .is_none());
-        }
-
-        #[test]
-        fn valid_one_level_verify_storage_proof() {
-            let key = StorageKey::try_new(
-                "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1",
-            ).unwrap();
-            let value = Felt::try_new("0x47616d65206f66204c69666520546f6b656e")
-                .unwrap();
-            let edge_node_string = r#"[{
-                "edge": {
-                    "child": "0x47616d65206f66204c69666520546f6b656e",
-                    "path": {
-                        "len": 231,
-                        "value": "0x3dfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1"
-                    }
-                }
-            }]"#;
-
-            let storage_proof = GetProofResult {
-                contract_data: Some(ContractData {
-                    root: Felt::try_new(
-                        "0x1e224db31dfb3e1b8c95670a12f1903d4a32ac7bb83f4b209029e14155bbca9",
-                    )
-                    .unwrap(),
-                    storage_proofs: Some(vec![serde_json::from_str(edge_node_string).unwrap()]),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            };
-            let contract_data = storage_proof.contract_data.as_ref().unwrap();
-
-            assert!(storage_proof
-                .verify_storage_proofs(contract_data, key, value)
-                .is_ok());
-        }
-
-        #[test]
-        fn invalid_one_level_verify_storage_proof() {
-            let key = StorageKey::try_new("0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1").unwrap();
-            let value = Felt::try_new("0xdef").unwrap();
-            let edge_node_string = r#"[{
-                "edge": {
-                    "child": "0xbad",
-                    "path": {
-                        "len": 231,
-                        "value": "0xfaa"
-                    }
-                }
-            }]"#;
-
-            let storage_proof = GetProofResult {
-                contract_data: Some(ContractData {
-                    root: Felt::try_new("0x42").unwrap(),
-                    storage_proofs: Some(vec![serde_json::from_str(
-                        edge_node_string,
-                    )
-                    .unwrap()]),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            };
-            let contract_data = storage_proof.contract_data.as_ref().unwrap();
-
-            assert!(storage_proof
-                .verify_storage_proofs(contract_data, key, value)
-                .is_err());
-        }
-
-        #[test]
-        fn contract_state_hash_is_valid() {
-            let contract_data = ContractData {
-                class_hash: Felt::try_new("0x123").unwrap(),
-                root: Felt::try_new("0xabc").unwrap(),
-                nonce: Felt::try_new("0xdef").unwrap(),
-                ..Default::default()
-            };
-            assert_eq!(
-                GetProofResult::calculate_contract_state_hash(&contract_data).unwrap(),
-                Felt::try_new("0x30a3c317f49a18c65bb5d22c87172f3f60101d54425457a66237474dd2d66db")
-                    .unwrap()
-            );
-        }
-
-        #[test]
-        fn calculate_global_root_is_valid() {
-            assert_eq!(
-                GetProofResult::calculate_global_root(
-                    &Felt::try_new("0xabc").unwrap(),
-                    Felt::try_new("0xdef").unwrap()
-                ).unwrap(),
-                Felt::try_new("0x42e26eb87a82c4b4130cb6bfbd33be7788436aa66f787ede4aef9456b58939")
-                    .unwrap()
-            );
-        }
-
-        #[test]
-        fn valid_verify_contract_proof() {
-            let edge_node_string = r#"[{
-                "edge": {
-                    "child": "0x538a7653ef22e217f93066ac54784c0159a5e1e37d808f83c82d1b42d57457d",
-                    "path": {
-                        "len": 229,
-                        "value": "0x4a03bb9e744479e3298f54705a35966ab04140d3d8dd797c1f6dc49d0"
-                    }
-                }
-            }]"#;
-            let storage_proof = GetProofResult {
-                contract_proof: serde_json::from_str(edge_node_string).unwrap(),
-                state_commitment: Some(
-                    Felt::try_new("0x1e2a7a7ee40c1d897c8c0a9515720ea02c8075ee9e00db277f5f8c3e4edcb54")
-                        .unwrap(),
-                ),
-                contract_data: Some(ContractData {
-                    class_hash: Felt::try_new(
-                        "0x4e635d495504b31ec191cbfc3d99b5d109bfcae4d0d9e16f4909a43b2e24c07",
-                    )
-                    .unwrap(),
-                    root: Felt::try_new(
-                        "0x5826149cbab3f8538d346301869ba2742a159d1542463ce19a60a927b826a2f",
-                    )
-                    .unwrap(),
-                    nonce: Felt::try_new("0x0").unwrap(),
-                    ..Default::default()
-                }),
-                class_commitment: Some(Felt::try_new("0x0").unwrap()),
-            };
-
-            let global_root =
-                Felt::try_new("0x1e2a7a7ee40c1d897c8c0a9515720ea02c8075ee9e00db277f5f8c3e4edcb54")
-                    .unwrap();
-            let contract_address = Address(Felt::try_new("0x6a05844a03bb9e744479e3298f54705a35966ab04140d3d8dd797c1f6dc49d0")
-                    .unwrap());
-            let contract_data = storage_proof.contract_data.as_ref().unwrap();
-            assert!(storage_proof
-                .verify_contract_proof(
-                    contract_data,
-                    global_root,
-                    contract_address
-                )
-                .is_ok());
-        }
-
-        #[test]
-        fn invalid_verify_contract_proof() {
-            let invalid_storage_proof = GetProofResult {
-                state_commitment: Some(Felt::try_new("0x0").unwrap()),
-                class_commitment: Some(Felt::try_new("0x0").unwrap()),
-                ..Default::default()
-            };
-            let global_root = Felt::try_new("0x0").unwrap();
-            let contract_address = Address(Felt::try_new("0x0").unwrap());
-            let contract_data = ContractData::default();
-            assert!(invalid_storage_proof
-                .verify_contract_proof(
-                    &contract_data,
-                    global_root,
-                    contract_address
-                )
-                .is_err());
         }
     }
 }

--- a/crates/experimental-api/src/gen.rs
+++ b/crates/experimental-api/src/gen.rs
@@ -106,7 +106,7 @@ pub mod gen {
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
     #[serde(try_from = "i64")]
-    pub struct BlockNumber(i64);
+    pub struct BlockNumber(pub i64);
 
     mod blocknumber {
         use super::jsonrpc;

--- a/crates/experimental-api/src/gen.rs
+++ b/crates/experimental-api/src/gen.rs
@@ -9722,9 +9722,9 @@ pub mod gen {
                     }
                 }
             }]"#;
-            let mut proof: Vec<Node> =
-                serde_json::from_str(&edge_node_string).unwrap();
-            let ret_val = GetProofResult::parse_proof(key, value, &mut proof);
+            let proof: Vec<Node> =
+                serde_json::from_str(edge_node_string).unwrap();
+            let ret_val = GetProofResult::parse_proof(key, value, &proof);
 
             assert!(ret_val.is_some());
             let ret_val = ret_val.unwrap();
@@ -9776,9 +9776,8 @@ pub mod gen {
                     }
                 }
             }]"#;
-            let mut proof: Vec<Node> =
-                serde_json::from_str(&proof_string).unwrap();
-            let ret_val = GetProofResult::parse_proof(key, value, &mut proof);
+            let proof: Vec<Node> = serde_json::from_str(proof_string).unwrap();
+            let ret_val = GetProofResult::parse_proof(key, value, &proof);
 
             assert!(ret_val.is_some());
             let ret_val = ret_val.unwrap();
@@ -9792,7 +9791,7 @@ pub mod gen {
         fn invalid_one_level_parse_proof() {
             let key = "0xabc".to_string();
             let value = Felt::try_new("0xdef").unwrap();
-            let mut proof: Vec<Node> = serde_json::from_str(
+            let proof: Vec<Node> = serde_json::from_str(
                 r#"[{
                 "edge": {
                     "child": "0xfaa",
@@ -9804,9 +9803,7 @@ pub mod gen {
             }]"#,
             )
             .unwrap();
-            assert!(
-                GetProofResult::parse_proof(key, value, &mut proof).is_none()
-            );
+            assert!(GetProofResult::parse_proof(key, value, &proof).is_none());
         }
 
         #[test]
@@ -9823,11 +9820,9 @@ pub mod gen {
                     }
                 }
             }]"#;
-            let mut proof: Vec<Node> =
-                serde_json::from_str(&edge_node_string).unwrap();
-            assert!(
-                GetProofResult::parse_proof(key, value, &mut proof).is_none()
-            );
+            let proof: Vec<Node> =
+                serde_json::from_str(edge_node_string).unwrap();
+            assert!(GetProofResult::parse_proof(key, value, &proof).is_none());
         }
 
         #[test]
@@ -9872,11 +9867,8 @@ pub mod gen {
                     }
                 }
             }]"#;
-            let mut proof: Vec<Node> =
-                serde_json::from_str(&proof_string).unwrap();
-            assert!(
-                GetProofResult::parse_proof(key, value, &mut proof).is_none()
-            );
+            let proof: Vec<Node> = serde_json::from_str(proof_string).unwrap();
+            assert!(GetProofResult::parse_proof(key, value, &proof).is_none());
         }
 
         #[test]
@@ -9902,7 +9894,7 @@ pub mod gen {
                         "0x1e224db31dfb3e1b8c95670a12f1903d4a32ac7bb83f4b209029e14155bbca9",
                     )
                     .unwrap(),
-                    storage_proofs: Some(vec![serde_json::from_str(&edge_node_string).unwrap()]),
+                    storage_proofs: Some(vec![serde_json::from_str(edge_node_string).unwrap()]),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -9932,7 +9924,7 @@ pub mod gen {
                 contract_data: Some(ContractData {
                     root: Felt::try_new("0x42").unwrap(),
                     storage_proofs: Some(vec![serde_json::from_str(
-                        &edge_node_string,
+                        edge_node_string,
                     )
                     .unwrap()]),
                     ..Default::default()
@@ -9985,7 +9977,7 @@ pub mod gen {
                 }
             }]"#;
             let storage_proof = GetProofResult {
-                contract_proof: serde_json::from_str(&edge_node_string).unwrap(),
+                contract_proof: serde_json::from_str(edge_node_string).unwrap(),
                 state_commitment: Some(
                     Felt::try_new("0x1e2a7a7ee40c1d897c8c0a9515720ea02c8075ee9e00db277f5f8c3e4edcb54")
                         .unwrap(),
@@ -10003,7 +9995,6 @@ pub mod gen {
                     ..Default::default()
                 }),
                 class_commitment: Some(Felt::try_new("0x0").unwrap()),
-                ..Default::default()
             };
 
             let global_root =

--- a/crates/experimental-api/src/lib.rs
+++ b/crates/experimental-api/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod exe;
 pub mod gen;
+pub mod proof_validation;
 pub mod rpc;

--- a/crates/experimental-api/src/proof_validation/mod.rs
+++ b/crates/experimental-api/src/proof_validation/mod.rs
@@ -1,0 +1,647 @@
+use beerus_core::{
+    storage_proofs::types::Direction,
+    utils::{felt_from_bits, felt_to_bits},
+};
+use iamgroot::jsonrpc;
+use starknet_crypto::{pedersen_hash, poseidon_hash_many, FieldElement};
+
+use crate::gen::{
+    Address, BinaryNode, BinaryNodeBinary, ContractData, EdgeNode,
+    EdgeNodeEdge, Felt, GetProofResult, Node, StorageKey,
+};
+
+impl GetProofResult {
+    pub fn verify(
+        &mut self,
+        global_root: Felt,
+        contract_address: Address,
+        key: StorageKey,
+        value: Felt,
+    ) -> Result<(), jsonrpc::Error> {
+        let contract_data = self.contract_data.as_ref().ok_or(
+            jsonrpc::Error::new(-32700, "No contract data found".to_string()),
+        )?;
+        self.verify_storage_proofs(contract_data, key, value)?;
+        self.verify_contract_proof(contract_data, global_root, contract_address)
+    }
+
+    fn verify_storage_proofs(
+        &self,
+        contract_data: &ContractData,
+        key: StorageKey,
+        value: Felt,
+    ) -> Result<(), jsonrpc::Error> {
+        let root = &contract_data.root;
+        let storage_proofs = &contract_data.storage_proofs.as_ref().ok_or(
+            jsonrpc::Error::new(-32700, "No storage proof found".to_string()),
+        )?[0];
+
+        match Self::parse_proof(key.as_ref(), value, storage_proofs)? {
+            Some(computed_root) => match computed_root == *root {
+                true => Ok(()),
+                false => Err(jsonrpc::Error::new(
+                    -32700,
+                    format!(
+                        "Proof invalid:\nprovided-root -> {}\ncomputed-root -> {}\n",
+                        root.as_ref(), computed_root.as_ref()
+                    ),
+                )),
+            },
+            None => Err(jsonrpc::Error::new(
+                -32700,
+                format!("Proof invalid for root -> {}\n", root.as_ref()),
+            )),
+        }
+    }
+
+    fn verify_contract_proof(
+        &self,
+        contract_data: &ContractData,
+        global_root: Felt,
+        contract_address: Address,
+    ) -> Result<(), jsonrpc::Error> {
+        let state_hash = Self::calculate_contract_state_hash(contract_data)?;
+
+        match Self::parse_proof(
+            contract_address.0.as_ref(),
+            state_hash,
+            &self.contract_proof,
+        )? {
+            Some(storage_commitment) => {
+                let class_commitment = self.class_commitment.as_ref().ok_or(
+                    jsonrpc::Error::new(
+                        -32700,
+                        "No class commitment".to_string(),
+                    ),
+                )?;
+                let parsed_global_root = Self::calculate_global_root(
+                    class_commitment,
+                    storage_commitment,
+                )
+                .map_err(|_| {
+                    jsonrpc::Error::new(
+                        -32700,
+                        "Failed to calculate global root".to_string(),
+                    )
+                })?;
+                let state_commitment = self.state_commitment.as_ref().ok_or(
+                    jsonrpc::Error::new(
+                        -32700,
+                        "No state commitment".to_string(),
+                    ),
+                )?;
+                match *state_commitment == parsed_global_root && global_root == parsed_global_root {
+                    true => Ok(()),
+                    false => Err(jsonrpc::Error::new(
+                        -32700,
+                        format!("Proof invalid:\nstate commitment -> {}\nparsed global root -> {}\n global root -> {}", 
+                        state_commitment.as_ref(), parsed_global_root.as_ref(), global_root.as_ref())
+                    )),
+                }
+            }
+            None => Err(jsonrpc::Error::new(
+                -32700,
+                format!(
+                    "Could not parse global root for root: {}",
+                    global_root.as_ref()
+                ),
+            )),
+        }
+    }
+
+    fn calculate_contract_state_hash(
+        contract_data: &ContractData,
+    ) -> Result<Felt, jsonrpc::Error> {
+        // The contract state hash is defined as H(H(H(hash, root), nonce), CONTRACT_STATE_HASH_VERSION)
+        const CONTRACT_STATE_HASH_VERSION: FieldElement = FieldElement::ZERO;
+        let hash = pedersen_hash(
+            &FieldElement::from_hex_be(contract_data.class_hash.as_ref())
+                .map_err(|_| {
+                    jsonrpc::Error::new(
+                        -32701,
+                        "Failed to create Field Element".to_string(),
+                    )
+                })?,
+            &FieldElement::from_hex_be(contract_data.root.as_ref()).map_err(
+                |_| {
+                    jsonrpc::Error::new(
+                        -32701,
+                        "Failed to create Field Element".to_string(),
+                    )
+                },
+            )?,
+        );
+        let hash = pedersen_hash(
+            &hash,
+            &FieldElement::from_hex_be(contract_data.nonce.as_ref()).map_err(
+                |_| {
+                    jsonrpc::Error::new(
+                        -32701,
+                        "Failed to create Field Element".to_string(),
+                    )
+                },
+            )?,
+        );
+        let hash = pedersen_hash(&hash, &CONTRACT_STATE_HASH_VERSION);
+        Felt::try_new(&format!("0x{:x}", hash)).map_err(|_| {
+            jsonrpc::Error::new(
+                -32701,
+                "Failed to create Field Element".to_string(),
+            )
+        })
+    }
+
+    fn calculate_global_root(
+        class_commitment: &Felt,
+        storage_commitment: Felt,
+    ) -> Result<Felt, jsonrpc::Error> {
+        let global_state_ver = FieldElement::from_byte_slice_be(
+            b"STARKNET_STATE_V0",
+        )
+        .map_err(|_| {
+            jsonrpc::Error::new(
+                -32701,
+                "Failed to create Field Element".to_string(),
+            )
+        })?;
+        let hash = poseidon_hash_many(&[
+            global_state_ver,
+            FieldElement::from_hex_be(storage_commitment.as_ref()).map_err(
+                |_| {
+                    jsonrpc::Error::new(
+                        -32701,
+                        "Failed to create Field Element".to_string(),
+                    )
+                },
+            )?,
+            FieldElement::from_hex_be(class_commitment.as_ref()).map_err(
+                |_| {
+                    jsonrpc::Error::new(
+                        -32701,
+                        "Failed to create Field Element".to_string(),
+                    )
+                },
+            )?,
+        ]);
+        Felt::try_new(&format!("0x{:x}", hash)).map_err(|_| {
+            jsonrpc::Error::new(
+                -32701,
+                "Failed to create Field Element".to_string(),
+            )
+        })
+    }
+
+    fn parse_proof(
+        key: impl Into<String>,
+        value: Felt,
+        proof: &[Node],
+    ) -> Result<Option<Felt>, jsonrpc::Error> {
+        let key = felt_to_bits(
+            FieldElement::from_hex_be(&key.into()).map_err(|_| {
+                jsonrpc::Error::new(
+                    -32701,
+                    "Failed to create Field Element".to_string(),
+                )
+            })?,
+        );
+        if key.len() != 251 {
+            return Ok(None);
+        }
+        let value =
+            FieldElement::from_hex_be(value.as_ref()).map_err(|_| {
+                jsonrpc::Error::new(
+                    -32701,
+                    "Failed to create Field Element".to_string(),
+                )
+            })?;
+        // initialized to the value so if the last node
+        // in the proof is a binary node we can still verify
+        let (mut hold, mut path_len) = (value, 0);
+        // reverse the proof in order to hash from the leaf towards the root
+        for (i, node) in proof.iter().rev().enumerate() {
+            match node {
+                Node::EdgeNode(EdgeNode {
+                    edge: EdgeNodeEdge { child, path },
+                }) => {
+                    // calculate edge hash given by provider
+                    let child_felt = FieldElement::from_hex_be(child.as_ref())
+                        .map_err(|_| {
+                            jsonrpc::Error::new(
+                                -32701,
+                                "Failed to create Field Element".to_string(),
+                            )
+                        })?;
+                    let path_value =
+                        FieldElement::from_hex_be(path.value.as_ref())
+                            .map_err(|_| {
+                                jsonrpc::Error::new(
+                                    -32701,
+                                    "Failed to create Field Element"
+                                        .to_string(),
+                                )
+                            })?;
+                    let provided_hash = pedersen_hash(&child_felt, &path_value)
+                        + FieldElement::from(path.len as u64);
+                    if i == 0 {
+                        // mask storage key
+                        let computed_hash = match felt_from_bits(
+                            &key,
+                            Some(251 - path.len as usize),
+                        ) {
+                            Ok(masked_key) => {
+                                pedersen_hash(&value, &masked_key)
+                                    + FieldElement::from(path.len as u64)
+                            }
+                            Err(_) => return Ok(None),
+                        };
+                        // verify computed hash against provided hash
+                        if provided_hash != computed_hash {
+                            return Ok(None);
+                        };
+                    }
+
+                    // walk up the remaining path
+                    path_len += path.len;
+                    hold = provided_hash;
+                }
+                Node::BinaryNode(BinaryNode {
+                    binary: BinaryNodeBinary { left, right },
+                }) => {
+                    path_len += 1;
+                    let left = FieldElement::from_hex_be(left.as_ref())
+                        .map_err(|_| {
+                            jsonrpc::Error::new(
+                                -32701,
+                                "Failed to create Field Element".to_string(),
+                            )
+                        })?;
+                    let right = FieldElement::from_hex_be(right.as_ref())
+                        .map_err(|_| {
+                            jsonrpc::Error::new(
+                                -32701,
+                                "Failed to create Field Element".to_string(),
+                            )
+                        })?;
+                    // identify path direction for this node
+                    let expected_hash =
+                        match Direction::from(key[251 - path_len as usize]) {
+                            Direction::Left => pedersen_hash(&hold, &right),
+                            Direction::Right => pedersen_hash(&left, &hold),
+                        };
+
+                    hold = pedersen_hash(&left, &right);
+                    // verify calculated hash vs provided hash for the node
+                    if hold != expected_hash {
+                        return Ok(None);
+                    };
+                }
+            };
+        }
+
+        Ok(Some(Felt::try_new(&format!("0x{:x}", hold))?))
+    }
+}
+#[cfg(test)]
+mod tests {
+    use crate::gen::{
+        Address, ContractData, Felt, GetProofResult, Node, StorageKey,
+    };
+
+    #[test]
+    fn valid_one_level_parse_proof() {
+        let key = "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1".to_string();
+        let value =
+            Felt::try_new("0x47616d65206f66204c69666520546f6b656e").unwrap();
+        let edge_node_string = r#"[{
+            "edge": {
+                "child": "0x47616d65206f66204c69666520546f6b656e",
+                "path": {
+                    "len": 231,
+                    "value": "0x3dfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1"
+                }
+            }
+        }]"#;
+        let proof: Vec<Node> = serde_json::from_str(edge_node_string).unwrap();
+        let ret_val = GetProofResult::parse_proof(key, value, &proof).unwrap();
+
+        assert!(ret_val.is_some());
+        let ret_val = ret_val.unwrap();
+        assert_eq!(
+            ret_val.as_ref(),
+            "0x1e224db31dfb3e1b8c95670a12f1903d4a32ac7bb83f4b209029e14155bbca9"
+        );
+    }
+
+    #[test]
+    fn valid_five_level_parse_proof() {
+        let key = "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1".to_string();
+        let value =
+            Felt::try_new("0x47616d65206f66204c69666520546f6b656e").unwrap();
+        let proof_string = r#"[
+        {
+            "binary": {
+                "left": "0x46e82293b0564764a071f1aa4488aa7577b1b5bb2e898321f8536d5593d371d",
+                "right": "0x58adcf6ea8b96992aa316e2f092f2480ca406c3630fe97573046a32900745b5"
+            }
+        },
+        {
+            "binary": {
+                "left": "0x716e211c75f4c0e14dbe46c361812b0129abd061b63faf91ad5569bf22b785c",
+                "right": "0x3729d9699d4410223e413f3b3aa91a043d94242f888188036e6ea25b6962041"
+            }
+        },
+        {
+            "edge": {
+                "child": "0x6281e42b5941ae1a77ea03836aad1190097f72e1a1ed534fae2e00b4118f504",
+                "path": {
+                    "len": 1,
+                    "value": "0x1"
+                }
+            }
+        },
+        {
+            "binary": {
+                "left": "0x3e3800516f62800ef6491b1cb1915b3353026ea6a6afcf35e8d4c54e35b04ea",
+                "right": "0x1e224db31dfb3e1b8c95670a12f1903d4a32ac7bb83f4b209029e14155bbca9"
+            }
+        },
+        {
+            "edge": {
+                "child": "0x47616d65206f66204c69666520546f6b656e",
+                "path": {
+                    "len": 231,
+                    "value": "0x3dfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1"
+                }
+            }
+        }]"#;
+        let proof: Vec<Node> = serde_json::from_str(proof_string).unwrap();
+        let ret_val = GetProofResult::parse_proof(key, value, &proof).unwrap();
+
+        assert!(ret_val.is_some());
+        let ret_val = ret_val.unwrap();
+        assert_eq!(
+            ret_val.as_ref(),
+            "0x6cc50a732b4256f7b642348e19bd1a8bee7ac76bed3fcee3bc34309538c00c6"
+        );
+    }
+
+    #[test]
+    fn invalid_one_level_parse_proof() {
+        let key = "0xabc".to_string();
+        let value = Felt::try_new("0xdef").unwrap();
+        let proof: Vec<Node> = serde_json::from_str(
+            r#"[{
+            "edge": {
+                "child": "0xfaa",
+                "path": {
+                    "len": 1,
+                    "value": "0xbad"
+                }
+            }
+        }]"#,
+        )
+        .unwrap();
+        assert!(GetProofResult::parse_proof(key, value, &proof)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn invalid_one_level_proof_last_key_byte_2_instead_of_1() {
+        let key = "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be2".to_string();
+        let value =
+            Felt::try_new("0x47616d65206f66204c69666520546f6b656e").unwrap();
+        let edge_node_string = r#"[{
+            "edge": {
+                "child": "0x47616d65206f66204c69666520546f6b656e",
+                "path": {
+                    "len": 231,
+                    "value": "0x3dfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1"
+                }
+            }
+        }]"#;
+        let proof: Vec<Node> = serde_json::from_str(edge_node_string).unwrap();
+        assert!(GetProofResult::parse_proof(key, value, &proof)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn invalid_five_level_proof_len_7_instead_of_1() {
+        let key = "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1".to_string();
+        let value =
+            Felt::try_new("0x47616d65206f66204c69666520546f6b656e").unwrap();
+        let proof_string = r#"[
+        {
+            "binary": {
+                "left": "0x46e82293b0564764a071f1aa4488aa7577b1b5bb2e898321f8536d5593d371d",
+                "right": "0x58adcf6ea8b96992aa316e2f092f2480ca406c3630fe97573046a32900745b5"
+            }
+        },
+        {
+            "binary": {
+                "left": "0x716e211c75f4c0e14dbe46c361812b0129abd061b63faf91ad5569bf22b785c",
+                "right": "0x3729d9699d4410223e413f3b3aa91a043d94242f888188036e6ea25b6962041"
+            }
+        },
+        {
+            "edge": {
+                "child": "0x6281e42b5941ae1a77ea03836aad1190097f72e1a1ed534fae2e00b4118f504",
+                "path": {
+                    "len": 7,
+                    "value": "0x1"
+                }
+            }
+        },
+        {
+            "binary": {
+                "left": "0x3e3800516f62800ef6491b1cb1915b3353026ea6a6afcf35e8d4c54e35b04ea",
+                "right": "0x1e224db31dfb3e1b8c95670a12f1903d4a32ac7bb83f4b209029e14155bbca9"
+            }
+        },
+        {
+            "edge": {
+                "child": "0x47616d65206f66204c69666520546f6b656e",
+                "path": {
+                    "len": 231,
+                    "value": "0x3dfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1"
+                }
+            }
+        }]"#;
+        let proof: Vec<Node> = serde_json::from_str(proof_string).unwrap();
+        assert!(GetProofResult::parse_proof(key, value, &proof)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn valid_one_level_verify_storage_proof() {
+        let key = StorageKey::try_new(
+            "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1",
+        ).unwrap();
+        let value =
+            Felt::try_new("0x47616d65206f66204c69666520546f6b656e").unwrap();
+        let edge_node_string = r#"[{
+            "edge": {
+                "child": "0x47616d65206f66204c69666520546f6b656e",
+                "path": {
+                    "len": 231,
+                    "value": "0x3dfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1"
+                }
+            }
+        }]"#;
+
+        let storage_proof = GetProofResult {
+            contract_data: Some(ContractData {
+                root: Felt::try_new(
+                    "0x1e224db31dfb3e1b8c95670a12f1903d4a32ac7bb83f4b209029e14155bbca9",
+                )
+                .unwrap(),
+                storage_proofs: Some(vec![serde_json::from_str(edge_node_string).unwrap()]),
+                class_hash: Felt::try_new("0x0").unwrap(),
+                contract_state_hash_version: Felt::try_new("0x0").unwrap(),
+                nonce: Felt::try_new("0x0").unwrap(),
+            }),
+            class_commitment: Some(Felt::try_new("0x0").unwrap()),
+            contract_proof: vec![],
+            state_commitment: Some(Felt::try_new("0x0").unwrap())
+        };
+        let contract_data = storage_proof.contract_data.as_ref().unwrap();
+
+        assert!(storage_proof
+            .verify_storage_proofs(contract_data, key, value)
+            .is_ok());
+    }
+
+    #[test]
+    fn invalid_one_level_verify_storage_proof() {
+        let key = StorageKey::try_new("0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1").unwrap();
+        let value = Felt::try_new("0xdef").unwrap();
+        let edge_node_string = r#"[{
+            "edge": {
+                "child": "0xbad",
+                "path": {
+                    "len": 231,
+                    "value": "0xfaa"
+                }
+            }
+        }]"#;
+
+        let storage_proof = GetProofResult {
+            contract_data: Some(ContractData {
+                root: Felt::try_new("0x42").unwrap(),
+                storage_proofs: Some(vec![serde_json::from_str(
+                    edge_node_string,
+                )
+                .unwrap()]),
+                class_hash: Felt::try_new("0x0").unwrap(),
+                contract_state_hash_version: Felt::try_new("0x0").unwrap(),
+                nonce: Felt::try_new("0x0").unwrap(),
+            }),
+            class_commitment: Some(Felt::try_new("0x0").unwrap()),
+            contract_proof: vec![],
+            state_commitment: Some(Felt::try_new("0x0").unwrap()),
+        };
+        let contract_data = storage_proof.contract_data.as_ref().unwrap();
+
+        assert!(storage_proof
+            .verify_storage_proofs(contract_data, key, value)
+            .is_err());
+    }
+
+    #[test]
+    fn contract_state_hash_is_valid() {
+        let contract_data = ContractData {
+            class_hash: Felt::try_new("0x123").unwrap(),
+            root: Felt::try_new("0xabc").unwrap(),
+            nonce: Felt::try_new("0xdef").unwrap(),
+            contract_state_hash_version: Felt::try_new("0x0").unwrap(),
+            storage_proofs: Some(vec![vec![]]),
+        };
+        assert_eq!(
+            GetProofResult::calculate_contract_state_hash(&contract_data).unwrap(),
+            Felt::try_new("0x30a3c317f49a18c65bb5d22c87172f3f60101d54425457a66237474dd2d66db")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn calculate_global_root_is_valid() {
+        assert_eq!(
+            GetProofResult::calculate_global_root(
+                &Felt::try_new("0xabc").unwrap(),
+                Felt::try_new("0xdef").unwrap()
+            ).unwrap(),
+            Felt::try_new("0x42e26eb87a82c4b4130cb6bfbd33be7788436aa66f787ede4aef9456b58939")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn valid_verify_contract_proof() {
+        let edge_node_string = r#"[{
+            "edge": {
+                "child": "0x538a7653ef22e217f93066ac54784c0159a5e1e37d808f83c82d1b42d57457d",
+                "path": {
+                    "len": 229,
+                    "value": "0x4a03bb9e744479e3298f54705a35966ab04140d3d8dd797c1f6dc49d0"
+                }
+            }
+        }]"#;
+        let storage_proof = GetProofResult {
+            contract_proof: serde_json::from_str(edge_node_string).unwrap(),
+            state_commitment: Some(
+                Felt::try_new("0x1e2a7a7ee40c1d897c8c0a9515720ea02c8075ee9e00db277f5f8c3e4edcb54")
+                    .unwrap(),
+            ),
+            contract_data: Some(ContractData {
+                class_hash: Felt::try_new(
+                    "0x4e635d495504b31ec191cbfc3d99b5d109bfcae4d0d9e16f4909a43b2e24c07",
+                )
+                .unwrap(),
+                root: Felt::try_new(
+                    "0x5826149cbab3f8538d346301869ba2742a159d1542463ce19a60a927b826a2f",
+                )
+                .unwrap(),
+                nonce: Felt::try_new("0x0").unwrap(),
+                contract_state_hash_version: Felt::try_new("0x0").unwrap(),
+                storage_proofs: Some(vec![vec![]])
+            }),
+            class_commitment: Some(Felt::try_new("0x0").unwrap()),
+        };
+
+        let global_root = Felt::try_new(
+            "0x1e2a7a7ee40c1d897c8c0a9515720ea02c8075ee9e00db277f5f8c3e4edcb54",
+        )
+        .unwrap();
+        let contract_address = Address(Felt::try_new("0x6a05844a03bb9e744479e3298f54705a35966ab04140d3d8dd797c1f6dc49d0")
+                .unwrap());
+        let contract_data = storage_proof.contract_data.as_ref().unwrap();
+        assert!(storage_proof
+            .verify_contract_proof(contract_data, global_root, contract_address)
+            .is_ok());
+    }
+
+    #[test]
+    fn invalid_verify_contract_proof() {
+        let invalid_storage_proof = GetProofResult {
+            state_commitment: Some(Felt::try_new("0x0").unwrap()),
+            class_commitment: Some(Felt::try_new("0x0").unwrap()),
+            contract_data: Some(ContractData {
+                class_hash: Felt::try_new("0x0").unwrap(),
+                contract_state_hash_version: Felt::try_new("0x0").unwrap(),
+                nonce: Felt::try_new("0x0").unwrap(),
+                root: Felt::try_new("0x0").unwrap(),
+                storage_proofs: Some(vec![vec![]]),
+            }),
+            contract_proof: vec![],
+        };
+        let global_root = Felt::try_new("0x0").unwrap();
+        let contract_address = Address(Felt::try_new("0x0").unwrap());
+        let contract_data =
+            invalid_storage_proof.contract_data.as_ref().unwrap();
+        assert!(invalid_storage_proof
+            .verify_contract_proof(contract_data, global_root, contract_address)
+            .is_err());
+    }
+}

--- a/crates/experimental-api/src/rpc.rs
+++ b/crates/experimental-api/src/rpc.rs
@@ -130,6 +130,8 @@ impl Context {
                     block_number: BlockNumber::try_new(block_num)?,
                 })
             }
+            // TODO Resolve block hash to number
+            // and check if the number is acceptable
             gen::BlockId::BlockHash { block_hash } => {
                 Ok(gen::BlockId::BlockHash { block_hash })
             }

--- a/crates/experimental-api/tests/common/mod.rs
+++ b/crates/experimental-api/tests/common/mod.rs
@@ -5,6 +5,7 @@ use beerus_experimental_api::{
     gen::client::Client,
     rpc::{serve, Server},
 };
+use starknet_crypto::FieldElement;
 use thiserror::Error;
 use tokio::sync::RwLock;
 
@@ -17,7 +18,14 @@ pub struct Context {
 #[allow(dead_code)] // used in macros
 pub async fn ctx() -> Option<Context> {
     let url = std::env::var("BEERUS_EXPERIMENTAL_TEST_STARKNET_URL").ok()?;
-    let node = Arc::new(RwLock::new(NodeData::default()));
+    let node = Arc::new(RwLock::new(NodeData {
+        l1_block_number: 647978,
+        l1_state_root: FieldElement::from_hex_be(
+            "0x463aee312c3eeaa8351d59fec0ee5a87168434f07482b4e618a123936603d90",
+        )
+        .unwrap(),
+        ..Default::default()
+    }));
     let server = serve(&url, "127.0.0.1:0", node.clone()).await.ok()?;
     tracing::info!(port = server.port(), "test server is up");
 

--- a/crates/experimental-api/tests/common/mod.rs
+++ b/crates/experimental-api/tests/common/mod.rs
@@ -1,8 +1,12 @@
+use std::sync::Arc;
+
+use beerus_core::client::NodeData;
 use beerus_experimental_api::{
     gen::client::Client,
     rpc::{serve, Server},
 };
 use thiserror::Error;
+use tokio::sync::RwLock;
 
 #[allow(dead_code)] // used in macros
 pub struct Context {
@@ -13,7 +17,8 @@ pub struct Context {
 #[allow(dead_code)] // used in macros
 pub async fn ctx() -> Option<Context> {
     let url = std::env::var("BEERUS_EXPERIMENTAL_TEST_STARKNET_URL").ok()?;
-    let server = serve(&url, "127.0.0.1:0").await.ok()?;
+    let node = Arc::new(RwLock::new(NodeData::default()));
+    let server = serve(&url, "127.0.0.1:0", node.clone()).await.ok()?;
     tracing::info!(port = server.port(), "test server is up");
 
     let url = format!("http://localhost:{}/rpc", server.port());

--- a/crates/experimental-api/tests/common/mod.rs
+++ b/crates/experimental-api/tests/common/mod.rs
@@ -21,7 +21,7 @@ pub async fn ctx() -> Option<Context> {
     let node = Arc::new(RwLock::new(NodeData {
         l1_block_number: 647978,
         l1_state_root: FieldElement::from_hex_be(
-            "0x463aee312c3eeaa8351d59fec0ee5a87168434f07482b4e618a123936603d90",
+            "0x2a5aa70350b7d047cd3dd2f5ad01f8925409a64fc42e509e8e79c3a2c17425",
         )
         .unwrap(),
         ..Default::default()

--- a/crates/experimental-api/tests/rpc.rs
+++ b/crates/experimental-api/tests/rpc.rs
@@ -252,8 +252,7 @@ async fn test_getStorageAt() -> Result<(), Error> {
         "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1",
     )?;
 
-    let block_id =
-        BlockId::BlockNumber { block_number: BlockNumber::try_new(600612)? };
+    let block_id = BlockId::BlockTag(BlockTag::Latest);
 
     let ret = ctx.client.getStorageAt(contract_address, key, block_id).await?;
     assert_eq!(ret.as_ref(), "0x47616d65206f66204c69666520546f6b656e");

--- a/crates/experimental-api/tests/rpc.rs
+++ b/crates/experimental-api/tests/rpc.rs
@@ -252,7 +252,8 @@ async fn test_getStorageAt() -> Result<(), Error> {
         "0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1",
     )?;
 
-    let block_id = BlockId::BlockTag(BlockTag::Latest);
+    let block_id =
+        BlockId::BlockNumber { block_number: BlockNumber::try_new(600612)? };
 
     let ret = ctx.client.getStorageAt(contract_address, key, block_id).await?;
     assert_eq!(ret.as_ref(), "0x47616d65206f66204c69666520546f6b656e");


### PR DESCRIPTION
Proof validation exists in `crates::core::storage_proofs`. Due to new requirements, it has been also implemented for the new experimental-api. Branch workflow is as follows:

- Creation of unit tests in the` crates::core::storage_proofs` to check the original implementation
- Migration of implementation to `crates::core::experimental_api::gen`
- Migration of unit tests to validate that it has the same functionality
- Code cleanup

Things to be checked with more details:

- Unit tests that have been created - does something need to be added or changed
- `jsonrpc::error` - code value for the errors is it correctly done (possible feature `impl From<FromStrError>` to kick out boilerplate `map_err()?` or different implementation with the current scope)
- usage of `starknet::FieldElemen`t due to pedersen and poseidon hash - inside `parse_proof()` conversion from `gen::Felt` to `starknet::FieldElement` so that pedersen and poseidon hash functions could be called (additional usage of `felt_to_bits()` and `felt_from_bits()` from `crates::core::utils`)
- Beerus Client added to experimental-api bin - necessary to extract L1 block_num and state_root from node 

(Closes #619)