### PR TITLE
feat: adding source based coverage using cargo-llvm-cov

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -83,3 +83,23 @@ jobs:
       - uses: crate-ci/typos@v1.21.0
         with:
           files: .
+
+  coverage:
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov@v2
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --html --output-dir coverage
+      - name: Set up GitHub Pages
+        uses: actions/configure-pages@v3
+      - name: Upload coverage to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.GITHUB_TOKEN }}
+          external_repository: ${{ github.repository }}
+          publish_dir: ./coverage/html

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ target/
 node_modules
 
 tmp/
+coverage/


### PR DESCRIPTION
Using [cargo-llvm-coverage ](https://github.com/taiki-e/cargo-llvm-cov) to generate source based coverage. 
The library is wrapper of the compiler flag `-C instrument-coverage` more details [here](https://doc.rust-lang.org/rustc/instrument-coverage.html#instrumentation-based-code-coverage)

The command `cargo llvm-cov --all-features --workspace --html --output-dir coverage` was tested locally and it generated an html file with the coverage.

I used Github page to publish the .html file, but Codecov can be used too. I need to verify is there are free plan options.

Any change or suggest will be welcome!

#684 