### PR TITLE
chore: different error format

### DIFF
--- a/src/bin/beerus.rs
+++ b/src/bin/beerus.rs
@@ -40,7 +40,7 @@ async fn main() -> eyre::Result<()> {
                         tracing::info!(?state, "updated");
                     }
                     Err(e) => {
-                        tracing::error!(error=?e, "state update failed");
+                        tracing::error!(error=%e, "state update failed");
                     }
                 }
             }


### PR DESCRIPTION
In my opinion, users don't care that much about too detailed error messages. In fact, I believe that it just confuses them. With this commit, only the main error message is displayed.

Before:
<img width="1440" alt="Screenshot 2024-09-05 at 12 34 38" src="https://github.com/user-attachments/assets/ee745a3b-547d-4497-9a5d-ca16543f1e5b">

After:
<img width="1440" alt="Screenshot 2024-09-05 at 12 37 38" src="https://github.com/user-attachments/assets/14de6cd7-8fef-4d59-ba3b-41b620178623">
