### PR TITLE
feat!(config): drop `network` config property

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,55 +153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
-dependencies = [
- "anstyle",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,7 +556,6 @@ dependencies = [
  "bitvec 1.0.1",
  "blockifier 0.8.0-rc.2",
  "cairo-lang-starknet-classes 2.7.0",
- "clap",
  "ethers",
  "eyre",
  "flate2",
@@ -2144,46 +2094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim 0.11.1",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.77",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
-
-[[package]]
 name = "client"
 version = "0.5.5"
 source = "git+https://github.com/sergey-melnychuk/helios?branch=beerus-wasm#762a5508a2984b4c82d257b17fbfdc2bdf4fb4d5"
@@ -2274,12 +2184,6 @@ dependencies = [
  "sha3",
  "thiserror",
 ]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "colored"
@@ -4300,12 +4204,6 @@ dependencies = [
  "memchr",
  "serde",
 ]
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -8792,12 +8690,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 [features]
 default = ["rpc"]
 rpc = ["dep:axum"]
+testing = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ bitvec = "1.0.1"
 validator = { version = "0.18.1", features = ["derive"] }
 url = "2.5.1"
 toml = "0.8.19"
-clap = { version = "4.5.17", features = ["derive"] }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ The successful result should look similar to the one below:
 
 | field   | example | description |
 | ----------- | ----------- | ----------- |
-| ethereum_rpc | https://eth-mainnet.g.alchemy.com/v2/{YOUR_API_KEY}| untrusted l1 node provider url |
-| starknet_rpc | https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_7/{YOUR_API_KEY}| untrusted l2 node provider url |
-| data_dir | tmp | `OPTIONAL` location to store both l1 and l2 data |
+| ethereum_rpc | https://eth-mainnet.g.alchemy.com/v2/{YOUR_API_KEY}| untrusted L1 node provider url |
+| starknet_rpc | https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_7/{YOUR_API_KEY}| untrusted L2 node provider url |
+| data_dir | tmp | `OPTIONAL` location to store both L1 and L2 data |
 | poll_secs | 5 | `OPTIONAL` seconds to wait for querying sn state, min = 1 and max = 3600 |
 | rpc_addr | 127.0.0.1:3030 | `OPTIONAL` local address to listen for rpc reqs |
 

--- a/README.md
+++ b/README.md
@@ -55,23 +55,22 @@ The successful result should look similar to the one below:
 
 | field   | example | description |
 | ----------- | ----------- | ----------- |
-| network | MAINNET or SEPOLIA| network to query |
-| eth_execution_rpc | https://eth-mainnet.g.alchemy.com/v2/{YOUR_API_KEY}| untrusted l1 node provider url |
+| ethereum_rpc | https://eth-mainnet.g.alchemy.com/v2/{YOUR_API_KEY}| untrusted l1 node provider url |
 | starknet_rpc | https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_7/{YOUR_API_KEY}| untrusted l2 node provider url |
 | data_dir | tmp | `OPTIONAL` location to store both l1 and l2 data |
 | poll_secs | 5 | `OPTIONAL` seconds to wait for querying sn state, min = 1 and max = 3600 |
 | rpc_addr | 127.0.0.1:3030 | `OPTIONAL` local address to listen for rpc reqs |
 
-When you select a network, check that `eth_execution_rpc` and `starknet_rpc` urls also point to their corresponding networks. For example:
+When you select a network, check that `ethereum_rpc` and `starknet_rpc` urls also point to their corresponding networks. For example:
 
 MAINNET
 ```
-eth_execution_rpc = "https://eth-mainnet.g.alchemy.com/v2/{YOUR_API_KEY}"
+ethereum_rpc = "https://eth-mainnet.g.alchemy.com/v2/{YOUR_API_KEY}"
 starknet_rpc = "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_7/{YOUR_API_KEY}"
 ```
 SEPOLIA
 ```
-eth_execution_rpc = "https://eth-sepolia.g.alchemy.com/v2/{YOUR_API_KEY}"
+ethereum_rpc = "https://eth-sepolia.g.alchemy.com/v2/{YOUR_API_KEY}"
 starknet_rpc = "https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_7/{YOUR_API_KEY}"
 ```
 
@@ -159,7 +158,7 @@ docker build . -t beerus
 ```
 
 ```bash
-docker run -e NETWORK=<arg> -e ETH_EXECUTION_RPC=<arg> -e STARKNET_RPC=<arg> -it beerus
+docker run -e ETHEREUM_RPC=<arg> -e STARKNET_RPC=<arg> -it beerus
 ```
 
 #### Examples

--- a/etc/conf/.env.example
+++ b/etc/conf/.env.example
@@ -1,8 +1,5 @@
-# network, e.g. SEPOLIA
-NETWORK=MAINNET
-
 # Ethereum execution RPC URL
-ETH_EXECUTION_RPC=https://eth-mainnet.g.alchemy.com/v2/<YOUR_API_KEY>
+ETHEREUM_RPC=https://eth-mainnet.g.alchemy.com/v2/<YOUR_API_KEY>
 
 # StarkNet RPC URL, e.g. infura or pathfinder
 STARKNET_RPC=https://starknet-mainnet.g.alchemy.com/v2/<YOUR API KEY>

--- a/etc/conf/beerus.json
+++ b/etc/conf/beerus.json
@@ -1,5 +1,0 @@
-{
-    "network": "MAINNET",
-    "eth_execution_rpc": "https://eth-mainnet.g.alchemy.com/v2/<YOUR API KEY>",
-    "starknet_rpc": "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.6/<YOUR API KEY>"
-}

--- a/etc/conf/beerus.toml
+++ b/etc/conf/beerus.toml
@@ -1,5 +1,4 @@
-network = "MAINNET"
-eth_execution_rpc = "https://eth-mainnet.g.alchemy.com/v2/<YOUR API KEY>"
+ethereum_rpc = "https://eth-mainnet.g.alchemy.com/v2/<YOUR API KEY>"
 starknet_rpc = "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.6/<YOUR API KEY>"
 data_dir = "tmp"
 poll_secs = 5

--- a/examples/call.rs
+++ b/examples/call.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<()> {
             "https://eth-mainnet.g.alchemy.com/v2/{api_key}"
         ),
         starknet_rpc: format!(
-            "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.6/{api_key}"
+            "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_7/{api_key}"
         ),
         data_dir: "tmp".to_owned(),
     };

--- a/examples/call.rs
+++ b/examples/call.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use beerus::client::{Client, Http};
 use beerus::config::Config;
 use beerus::gen::{Address, Felt, FunctionCall};
@@ -13,14 +11,13 @@ async fn main() -> Result<()> {
         .context("ALCHEMY_API_KEY is missing")?;
 
     let config = Config {
-        network: helios::config::networks::Network::MAINNET,
-        eth_execution_rpc: format!(
+        ethereum_rpc: format!(
             "https://eth-mainnet.g.alchemy.com/v2/{api_key}"
         ),
         starknet_rpc: format!(
             "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.6/{api_key}"
         ),
-        data_dir: PathBuf::from("tmp"),
+        data_dir: "tmp".to_owned(),
     };
 
     let http = Http::new();

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -1,5 +1,3 @@
-use std::{env, path::PathBuf};
-
 use beerus::client::{Client, Http};
 use beerus::config::Config;
 use eyre::{Context, Result};
@@ -8,18 +6,17 @@ use eyre::{Context, Result};
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
-    let api_key =
-        env::var("ALCHEMY_API_KEY").context("ALCHEMY_API_KEY is missing")?;
+    let api_key = std::env::var("ALCHEMY_API_KEY")
+        .context("ALCHEMY_API_KEY is missing")?;
 
     let config = Config {
-        network: helios::config::networks::Network::MAINNET,
-        eth_execution_rpc: format!(
+        ethereum_rpc: format!(
             "https://eth-mainnet.g.alchemy.com/v2/{api_key}"
         ),
         starknet_rpc: format!(
             "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.6/{api_key}"
         ),
-        data_dir: PathBuf::from("tmp"),
+        data_dir: "tmp".to_owned(),
     };
 
     let http = Http::new();

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<()> {
             "https://eth-mainnet.g.alchemy.com/v2/{api_key}"
         ),
         starknet_rpc: format!(
-            "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.6/{api_key}"
+            "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_7/{api_key}"
         ),
         data_dir: "tmp".to_owned(),
     };

--- a/src/bin/beerus.rs
+++ b/src/bin/beerus.rs
@@ -58,7 +58,7 @@ async fn get_config() -> eyre::Result<ServerConfig> {
     let config = if let Some(path) = path {
         ServerConfig::from_file(&path)?
     } else {
-        ServerConfig::from_env()
+        ServerConfig::from_env()?
     };
     config.validate()?;
     check_data_dir(&config.client.data_dir)?;

--- a/src/bin/beerus.rs
+++ b/src/bin/beerus.rs
@@ -4,8 +4,6 @@ use beerus::{client::Http, config::{check_data_dir, ServerConfig}};
 use tokio::sync::RwLock;
 use validator::Validate;
 
-const RPC_SPEC_VERSION: &str = "0.7.1";
-
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     tracing_subscriber::fmt::init();
@@ -15,11 +13,6 @@ async fn main() -> eyre::Result<()> {
 
     let http = Http::new();
     let beerus = beerus::client::Client::new(&config.client, http).await?;
-
-    let rpc_spec_version = beerus.spec_version().await?;
-    if rpc_spec_version != RPC_SPEC_VERSION {
-        eyre::bail!("RPC spec version mismatch: expected {RPC_SPEC_VERSION} but got {rpc_spec_version}");
-    }
 
     let state = beerus.get_state().await?;
     tracing::info!(?state, "initialized");

--- a/src/bin/beerus.rs
+++ b/src/bin/beerus.rs
@@ -1,6 +1,9 @@
 use std::{sync::Arc, time::Duration};
 
-use beerus::{client::Http, config::{check_data_dir, ServerConfig}};
+use beerus::{
+    client::Http,
+    config::{check_data_dir, ServerConfig},
+};
 use tokio::sync::RwLock;
 use validator::Validate;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use eyre::{Context, Result};
 
-use crate::config::Config;
+use crate::config::{check_chain_id, Config};
 use crate::eth::{EthereumClient, Helios};
 use crate::gen::client::Client as StarknetClient;
 use crate::gen::{gen, Felt, FunctionCall, Rpc};
@@ -111,7 +111,9 @@ impl<
 {
     pub async fn new(config: &Config, http: T) -> Result<Self> {
         let starknet = StarknetClient::new(&config.starknet_rpc, http.clone());
-        let ethereum = EthereumClient::new(config).await?;
+        let network =
+            check_chain_id(&config.ethereum_rpc, &config.starknet_rpc).await?;
+        let ethereum = EthereumClient::new(config, network).await?;
         Ok(Self { starknet, ethereum, http })
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -41,6 +41,14 @@ async fn post<Q: serde::Serialize, R: serde::de::DeserializeOwned>(
     Ok(response)
 }
 
+impl PartialEq<State> for State {
+    fn eq(&self, other: &State) -> bool {
+        self.block_number == other.block_number
+            && self.root.as_ref() == other.root.as_ref()
+            && self.block_hash.as_ref() == other.block_hash.as_ref()
+    }
+}
+
 #[derive(Clone)]
 pub struct Http(pub reqwest::Client);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use helios::config::networks::Network;
 use serde::Deserialize;
 use validator::Validate;
 
+#[cfg(not(target_arch = "wasm32"))]
 const DEFAULT_DATA_DIR: &str = "tmp";
 const DEFAULT_POLL_SECS: u64 = 5;
 
@@ -37,10 +38,12 @@ pub struct Config {
     pub ethereum_rpc: String,
     #[validate(url)]
     pub starknet_rpc: String,
+    #[cfg(not(target_arch = "wasm32"))]
     #[serde(default = "default_data_dir")]
     pub data_dir: String,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn default_data_dir() -> String {
     DEFAULT_DATA_DIR.to_owned()
 }
@@ -71,6 +74,7 @@ impl ServerConfig {
                     .context("ETHEREUM_RPC env var missing")?,
                 starknet_rpc: std::env::var("STARKNET_RPC")
                     .context("STARKNET_RPC env var missing")?,
+                #[cfg(not(target_arch = "wasm32"))]
                 data_dir: std::env::var("DATA_DIR")
                     .unwrap_or_else(|_| default_data_dir()),
             },

--- a/src/config.rs
+++ b/src/config.rs
@@ -171,7 +171,9 @@ mod tests {
         matchers::body_partial_json, Mock, MockServer, ResponseTemplate,
     };
 
-    async fn mock(patterns: &[(serde_json::Value, serde_json::Value)]) -> MockServer {
+    async fn mock(
+        patterns: &[(serde_json::Value, serde_json::Value)],
+    ) -> MockServer {
         let server = MockServer::start().await;
         for (request, response) in patterns {
             Mock::given(body_partial_json(&request))
@@ -207,24 +209,25 @@ mod tests {
             (
                 serde_json::json!({
                     "method": "eth_chainId"
-                }), 
+                }),
                 serde_json::json!({
                     "id": 0,
                     "jsonrpc": "2.0",
-                    "result": MAINNET_ETHEREUM_CHAINID    
-                })
+                    "result": MAINNET_ETHEREUM_CHAINID
+                }),
             ),
             (
                 serde_json::json!({
                     "method": "starknet_chainId"
-                }), 
+                }),
                 serde_json::json!({
                     "id": 0,
                     "jsonrpc": "2.0",
-                    "result": MAINNET_STARKNET_CHAINID    
-                })
+                    "result": MAINNET_STARKNET_CHAINID
+                }),
             ),
-        ]).await;
+        ])
+        .await;
 
         let rpc = format!("http://{}/", server.address());
         let network = check_chain_id(&rpc, &rpc).await.expect("check_chain_id");
@@ -237,24 +240,25 @@ mod tests {
             (
                 serde_json::json!({
                     "method": "eth_chainId"
-                }), 
+                }),
                 serde_json::json!({
                     "id": 0,
                     "jsonrpc": "2.0",
-                    "result": SEPOLIA_ETHEREUM_CHAINID    
-                })
+                    "result": SEPOLIA_ETHEREUM_CHAINID
+                }),
             ),
             (
                 serde_json::json!({
                     "method": "starknet_chainId"
-                }), 
+                }),
                 serde_json::json!({
                     "id": 0,
                     "jsonrpc": "2.0",
-                    "result": SEPOLIA_STARKNET_CHAINID    
-                })
+                    "result": SEPOLIA_STARKNET_CHAINID
+                }),
             ),
-        ]).await;
+        ])
+        .await;
 
         let rpc = format!("http://{}/", server.address());
         let network = check_chain_id(&rpc, &rpc).await.expect("check_chain_id");
@@ -267,24 +271,25 @@ mod tests {
             (
                 serde_json::json!({
                     "method": "eth_chainId"
-                }), 
+                }),
                 serde_json::json!({
                     "id": 0,
                     "jsonrpc": "2.0",
                     "result": "0xA"
-                })
+                }),
             ),
             (
                 serde_json::json!({
                     "method": "starknet_chainId"
-                }), 
+                }),
                 serde_json::json!({
                     "id": 0,
                     "jsonrpc": "2.0",
                     "result": "0xB"
-                })
+                }),
             ),
-        ]).await;
+        ])
+        .await;
 
         let rpc = format!("http://{}/", server.address());
         let result = check_chain_id(&rpc, &rpc).await;
@@ -300,24 +305,25 @@ mod tests {
             (
                 serde_json::json!({
                     "method": "eth_chainId"
-                }), 
+                }),
                 serde_json::json!({
                     "id": 0,
                     "jsonrpc": "2.0",
                     "result": "0xcafebabe"
-                })
+                }),
             ),
             (
                 serde_json::json!({
                     "method": "starknet_chainId"
-                }), 
+                }),
                 serde_json::json!({
                     "id": 0,
                     "jsonrpc": "2.0",
                     "error": "computer says no"
-                })
+                }),
             ),
-        ]).await;
+        ])
+        .await;
 
         let rpc = format!("http://{}/", server.address());
         let result = check_chain_id(&rpc, &rpc).await;

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,9 @@ const SEPOLIA_ETHEREUM_CHAINID: &str = "0xaa36a7";
 const MAINNET_STARKNET_CHAINID: &str = "0x534e5f4d41494e";
 const SEPOLIA_STARKNET_CHAINID: &str = "0x534e5f5345504f4c4941";
 
+#[cfg(feature = "testing")]
+const KATANA_STARKNET_CHAINID: &str = "0x4b4154414e41";
+
 #[derive(Clone, Deserialize, Debug, Validate)]
 pub struct ServerConfig {
     #[serde(flatten)]
@@ -102,7 +105,18 @@ pub async fn check_chain_id(
         return Ok(Network::SEPOLIA);
     }
 
-    // TODO: add explicit support for Katana chain behind 'testing' feature flag
+    #[cfg(feature = "testing")]
+    if starknet_chain_id == KATANA_STARKNET_CHAINID {
+        return match ethereum_chain_id.as_str() {
+            MAINNET_ETHEREUM_CHAINID => Ok(Network::MAINNET),
+            SEPOLIA_ETHEREUM_CHAINID => Ok(Network::SEPOLIA),
+            _ => {
+                eyre::bail!(
+                    "Unexpected Ethereum chain_id: {ethereum_chain_id}"
+                );
+            }
+        };
+    }
 
     eyre::bail!("chain_id mismatch: ethereum={ethereum_chain_id}, starknet={starknet_chain_id}")
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,7 +176,7 @@ mod tests {
     ) -> MockServer {
         let server = MockServer::start().await;
         for (request, response) in patterns {
-            Mock::given(body_partial_json(&request))
+            Mock::given(body_partial_json(request))
                 .respond_with(
                     ResponseTemplate::new(200).set_body_json(response),
                 )

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -64,8 +64,10 @@ impl EthereumClient {
 
         Ok(Self {
             helios,
-            starknet_core_contract_address: get_core_contract_address(&network)?,
-        })    
+            starknet_core_contract_address: get_core_contract_address(
+                &network,
+            )?,
+        })
     }
 
     pub async fn latest(&self) -> Result<(u64, H256)> {

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -104,7 +104,7 @@ impl EthereumClient {
         let root: H256 =
             self.call(&data, tag).await.context("helios: state root")?;
 
-        tracing::info!(block_number, ?block_hash, ?root, "starknet state");
+        tracing::debug!(block_number, ?block_hash, ?root, "starknet state");
 
         Ok((block_number, block_hash, root))
     }

--- a/web/beerus-web/Cargo.lock
+++ b/web/beerus-web/Cargo.lock
@@ -121,55 +121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
-dependencies = [
- "anstyle",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,7 +407,6 @@ dependencies = [
  "bitvec 1.0.1",
  "blockifier",
  "cairo-lang-starknet-classes 2.7.0",
- "clap",
  "ethers",
  "eyre",
  "flate2",
@@ -1535,46 +1485,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim 0.11.1",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.77",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
-
-[[package]]
 name = "client"
 version = "0.5.5"
 source = "git+https://github.com/sergey-melnychuk/helios?branch=beerus-wasm#762a5508a2984b4c82d257b17fbfdc2bdf4fb4d5"
@@ -1650,12 +1560,6 @@ dependencies = [
  "sha3",
  "thiserror",
 ]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "colored"
@@ -3575,12 +3479,6 @@ name = "ipnet"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -7043,12 +6941,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/web/beerus-web/src/lib.rs
+++ b/web/beerus-web/src/lib.rs
@@ -1,5 +1,4 @@
 use std::rc::Rc;
-use std::str::FromStr;
 use wasm_bindgen::prelude::*;
 
 const MAINNET_ETHEREUM_CHAINID: &str = "0x1";
@@ -179,12 +178,8 @@ impl Beerus {
         web_sys::console::log_1(&"beerus: config valid".into());
 
         let config = beerus::config::Config {
-            network: helios::prelude::networks::Network::from_str(&config.network.to_ascii_lowercase())
-                .map_err(|e| JsValue::from_str(&format!("failed to parse network: {e:?}")))?,
-            eth_execution_rpc: config.ethereum_url,
+            ethereum_rpc: config.ethereum_url,
             starknet_rpc: config.starknet_url,
-            // TODO: `data_dir` is not used for wasm32 targets
-            data_dir: Default::default(),
         };
         web_sys::console::log_1(&"beerus: config ready".into());
 


### PR DESCRIPTION
The main goal of this PR is to suggest rather radical change in configuration of Beerus: get rid of the `network` config property - it is completely redundant, because RPC URL for Ethereum and Starknet identify the used chain. In such case the detection of the network is very simple and allows no space for misconfiguration: only if both Etherem and Starknet chain IDs match (for either Ethereum or Sepolia), then network is detected correctly. In all other cases (unless 'testing' feature is enabled, then support of Katana chain was added explicitly) the error is returned. 

Other less significant suggestions:
- drop JSON configuration support and leave only TOML
- fail when invalid config properties were provided (now it falls back to the defaults for some reason)
- log updated state only if it actually differs from the current one
- update and cleanup relevant test coverage
- sheck expected RPC version on the client (currently for some reason it is only done for server in the `beerus` binary)

I know that suggested changes are rather significant, but I believe it still makes sense to consider them, as they making Beerus more consistent and more usable. Ready to discuss in anyway.